### PR TITLE
Clarify browser based Javascript vs Node

### DIFF
--- a/topics/access-types.adoc
+++ b/topics/access-types.adoc
@@ -6,11 +6,12 @@ When you create a Client in admin console you may be wondering what the "Access 
 confidential::
   Confidential access type is for clients that need to perform a browser login and that you want to require a client secret when they turn an access code into an access token, (see http://tools.ietf.org/html/rfc6749#section-4.1.3[Access Token Request] in the OAuth 2.0 spec for more details).  The advantages of this is that it is a little extra security.
   Since Keycloak requires you to register valid redirect-uris, I'm not exactly sure what this little extra security is though.
-  :) The disadvantages of this access type is that confidential access type is pointless for pure Javascript clients as anybody could easily figure out your client's secret! 
+  :) The disadvantages of this access type is that confidential access type is pointless for browser based Javascript
+  clients as anybody could easily figure out your client's secret! 
 
 public::
   Public access type is for clients that need to perform a browser login and that you feel that the added extra security of confidential access type is not needed.
-  FYI, Pure javascript clients are by nature public. 
+  Browser based javascript clients are by nature public. Node clients may be confidential.
 
 bearer-only::
   Bearer-only access type means that the application only allows bearer token requests.


### PR DESCRIPTION
As I understand it, the "public nature" of javascript clients in the description here is due to the fact that the client secret would be exposed somewhere in a publicly accessible place. However, this is not the case for Node.js clients. Those clients will be running on the server side and are not necessarily required to be public. My proposed change attempts to clarify this a bit.