### PR TITLE
Note on specifying scope parameter

### DIFF
--- a/server_admin/topics/roles/client-roles.adoc
+++ b/server_admin/topics/roles/client-roles.adoc
@@ -4,8 +4,8 @@ Client roles are basically a namespace dedicated to a client.  Each client gets 
 under the `Roles` tab under each individual client.  You interact with this UI the same way you do for realm level roles.
 
 If the client has to explicitly request for another client's role, the role has to prefixed with the client's id when requesting via the scope parameter. For example, if the client id is `account` and the role is `admin`, the scope parameter should be:
- +
- +`scope=account/admin`
+ 
+ `scope=account/admin`
  
  As noted in the realm roles section, multiple roles are separated by spaces.
  

--- a/server_admin/topics/roles/client-roles.adoc
+++ b/server_admin/topics/roles/client-roles.adoc
@@ -2,3 +2,10 @@
 
 Client roles are basically a namespace dedicated to a client.  Each client gets its own namespace.  Client roles are managed
 under the `Roles` tab under each individual client.  You interact with this UI the same way you do for realm level roles.
+
+If the client has to explicitly request for another client's role, the role has to prefixed with the client's id when requesting via the scope parameter. For example, if the client id is `account` and the role is `admin`, the scope parameter should be:
+ +
+ +`scope=account/admin`
+ 
+ As noted in the realm roles section, multiple roles are separated by spaces.
+ 

--- a/server_admin/topics/roles/realm-roles.adoc
+++ b/server_admin/topics/roles/realm-roles.adoc
@@ -17,3 +17,6 @@ The localized value is then configured within property files in your theme.  See
 for more information on localization.  If a client requires user _consent_, this description string will be displayed on the
 consent page for the user.
 
+If the client has to explicitly request for a realm role, set `Scope Param Required` to true. The role then has to be specified via the `scope` parameter when requesting a token. Multiple realm roles are separated by space:
+
+`scope=admin user`


### PR DESCRIPTION
Spent half a day breaking my head on how to pass in a client specific role via the `scope` parameter when requesting a token. After a lot of searching, found this - http://lists.jboss.org/pipermail/keycloak-user/2015-November/003789.html.

Have updated the documentation to mention the same so that it can spare someone else the effort. Hopefully have gotten the formatting right!
