### PR TITLE
Fix build scripts that build the target documentation

### DIFF
--- a/authorization_services/buildGuide.sh
+++ b/authorization_services/buildGuide.sh
@@ -32,9 +32,15 @@ if [ ! -d target ]; then
    exit
 fi
 
+# Remove the guide directory path from the master.adoc file as it is not needed
+echo ""
+echo "Removing the guide directory path from the master.adoc file as it is not needed."
+echo "NOTE: This should really be done in the Python script!"
+find . -name 'master.adoc' -print | xargs sed -i 's/include::securing_apps\//include::/g'
+
 # Remove the html and build directories and then recreate the html/images/ directory
 if [ -d target/html ]; then
--   rm -r target/html/
+   rm -r target/html/
 fi
 if [ -d target/html ]; then
    rm -r target/html/

--- a/getting_started/buildGuide.sh
+++ b/getting_started/buildGuide.sh
@@ -32,9 +32,15 @@ if [ ! -d target ]; then
    exit
 fi
 
+# Remove the guide directory path from the master.adoc file as it is not needed
+echo ""
+echo "Removing the guide directory path from the master.adoc file as it is not needed."
+echo "NOTE: This should really be done in the Python script!"
+find . -name 'master.adoc' -print | xargs sed -i 's/include::securing_apps\//include::/g'
+
 # Remove the html and build directories and then recreate the html/images/ directory
 if [ -d target/html ]; then
--   rm -r target/html/
+   rm -r target/html/
 fi
 if [ -d target/html ]; then
    rm -r target/html/

--- a/securing_apps/buildGuide.sh
+++ b/securing_apps/buildGuide.sh
@@ -32,9 +32,15 @@ if [ ! -d target ]; then
    exit
 fi
 
+# Remove the guide directory path from the master.adoc file as it is not needed
+echo ""
+echo "Removing the guide directory path from the master.adoc file as it is not needed."
+echo "NOTE: This should really be done in the Python script!"
+find . -name 'master.adoc' -print | xargs sed -i 's/include::securing_apps\//include::/g'
+
 # Remove the html and build directories and then recreate the html/images/ directory
 if [ -d target/html ]; then
--   rm -r target/html/
+   rm -r target/html/
 fi
 if [ -d target/html ]; then
    rm -r target/html/

--- a/server_admin/buildGuide.sh
+++ b/server_admin/buildGuide.sh
@@ -32,9 +32,15 @@ if [ ! -d target ]; then
    exit
 fi
 
+# Remove the guide directory path from the master.adoc file as it is not needed
+echo ""
+echo "Removing the guide directory path from the master.adoc file as it is not needed."
+echo "NOTE: This should really be done in the Python script!"
+find . -name 'master.adoc' -print | xargs sed -i 's/include::securing_apps\//include::/g'
+
 # Remove the html and build directories and then recreate the html/images/ directory
 if [ -d target/html ]; then
--   rm -r target/html/
+   rm -r target/html/
 fi
 if [ -d target/html ]; then
    rm -r target/html/

--- a/server_development/buildGuide.sh
+++ b/server_development/buildGuide.sh
@@ -32,9 +32,15 @@ if [ ! -d target ]; then
    exit
 fi
 
+# Remove the guide directory path from the master.adoc file as it is not needed
+echo ""
+echo "Removing the guide directory path from the master.adoc file as it is not needed."
+echo "NOTE: This should really be done in the Python script!"
+find . -name 'master.adoc' -print | xargs sed -i 's/include::securing_apps\//include::/g'
+
 # Remove the html and build directories and then recreate the html/images/ directory
 if [ -d target/html ]; then
--   rm -r target/html/
+   rm -r target/html/
 fi
 if [ -d target/html ]; then
    rm -r target/html/

--- a/server_installation/buildGuide.sh
+++ b/server_installation/buildGuide.sh
@@ -32,9 +32,15 @@ if [ ! -d target ]; then
    exit
 fi
 
+# Remove the guide directory path from the master.adoc file as it is not needed
+echo ""
+echo "Removing the guide directory path from the master.adoc file as it is not needed."
+echo "NOTE: This should really be done in the Python script!"
+find . -name 'master.adoc' -print | xargs sed -i 's/include::securing_apps\//include::/g'
+
 # Remove the html and build directories and then recreate the html/images/ directory
 if [ -d target/html ]; then
--   rm -r target/html/
+   rm -r target/html/
 fi
 if [ -d target/html ]; then
    rm -r target/html/


### PR DESCRIPTION
@jenmalloy : This should fix the scripts. You need to remove the guide directory name from the include path in the master.adoc files. I modified the build script to do that, however, it should really be done in the the Python script and I don't know Python well enough to fix it there.