### PR TITLE
Add a scripts/buildGuides.sh script and fix individual build scripts

### DIFF
--- a/authorization_services/buildGuide.sh
+++ b/authorization_services/buildGuide.sh
@@ -27,6 +27,10 @@ while getopts "ht:" c
      esac
 done
 
+echo ""
+echo "********************************************"
+echo " Building $CURRENT_GUIDE                    "
+echo "********************************************"
 if [ ! -d target ]; then
    echo "You must run 'python gitlab-conversion.py' to convert the content before you run this script."
    exit
@@ -34,9 +38,15 @@ fi
 
 # Remove the guide directory path from the master.adoc file as it is not needed
 echo ""
+echo "***************************************************************************************"
 echo "Removing the guide directory path from the master.adoc file as it is not needed."
-echo "NOTE: This should really be done in the Python script!"
-find . -name 'master.adoc' -print | xargs sed -i 's/include::securing_apps\//include::/g'
+echo "NOTE: The guide directory path should probably be removed from the SUMMARY.adoc file,"
+echo "but since we do not know if it will break the upstream build, we are doing this here. "
+echo "If it can not be removed from the SUMMARY.adoc file, this should really be done in the "
+echo "Python script because otherwise you must run this script before porting content!"
+echo "***************************************************************************************"
+echo ""
+find . -name 'master.adoc' -print | xargs sed -i "s/include::$CURRENT_GUIDE\//include::/g"
 
 # Remove the html and build directories and then recreate the html/images/ directory
 if [ -d target/html ]; then
@@ -49,11 +59,6 @@ fi
 mkdir -p html
 cp -r target/images/ target/html/
 
-echo ""
-echo "********************************************"
-echo " Building $CURRENT_GUIDE                "
-echo "********************************************"
-echo ""
 echo "Building an asciidoctor version of the guide"
 asciidoctor -t -dbook -a toc -o target/html/$CURRENT_GUIDE.html target/master.adoc
 

--- a/getting_started/buildGuide.sh
+++ b/getting_started/buildGuide.sh
@@ -27,6 +27,10 @@ while getopts "ht:" c
      esac
 done
 
+echo ""
+echo "********************************************"
+echo " Building $CURRENT_GUIDE                    "
+echo "********************************************"
 if [ ! -d target ]; then
    echo "You must run 'python gitlab-conversion.py' to convert the content before you run this script."
    exit
@@ -34,9 +38,15 @@ fi
 
 # Remove the guide directory path from the master.adoc file as it is not needed
 echo ""
+echo "***************************************************************************************"
 echo "Removing the guide directory path from the master.adoc file as it is not needed."
-echo "NOTE: This should really be done in the Python script!"
-find . -name 'master.adoc' -print | xargs sed -i 's/include::securing_apps\//include::/g'
+echo "NOTE: The guide directory path should probably be removed from the SUMMARY.adoc file,"
+echo "but since we do not know if it will break the upstream build, we are doing this here. "
+echo "If it can not be removed from the SUMMARY.adoc file, this should really be done in the "
+echo "Python script because otherwise you must run this script before porting content!"
+echo "***************************************************************************************"
+echo ""
+find . -name 'master.adoc' -print | xargs sed -i "s/include::$CURRENT_GUIDE\//include::/g"
 
 # Remove the html and build directories and then recreate the html/images/ directory
 if [ -d target/html ]; then
@@ -49,11 +59,6 @@ fi
 mkdir -p html
 cp -r target/images/ target/html/
 
-echo ""
-echo "********************************************"
-echo " Building $CURRENT_GUIDE                "
-echo "********************************************"
-echo ""
 echo "Building an asciidoctor version of the guide"
 asciidoctor -t -dbook -a toc -o target/html/$CURRENT_GUIDE.html target/master.adoc
 

--- a/scripts/buildGuides.sh
+++ b/scripts/buildGuides.sh
@@ -1,0 +1,119 @@
+# Establish global variables to the docs and script dirs
+CURRENT_DIR="$( pwd -P)"
+SCRIPT_SRC="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
+DOCS_SRC="$( dirname $SCRIPT_SRC )"
+BUILD_RESULTS="Build Results:"
+BUILD_MESSAGE=$BUILD_RESULTS
+BLACK='\033[0;30m'
+RED='\033[0;31m'
+NO_COLOR="\033[0m"
+
+usage(){
+  cat <<EOM
+USAGE: $0 [OPTION]... <guide>
+
+DESCRIPTION: Build all of the guides (default) or a single guide.
+
+Run this script from either the root of your cloned repo or from the 'scripts'
+directory.  Example:
+  cd eap-documentation/scripts
+  $0
+
+OPTIONS:
+  -h       Print help.
+
+EXAMPLES:
+  Build all guides:
+   $0
+
+  Build a specific guide(s) from $DOCS_SRC:
+    $0 authorization_services
+    $0 securing_apps
+    $0 authorization_services securing_apps
+
+EOM
+# Now list the valid book values
+listvalidbooks
+}
+
+listvalidbooks(){
+  echo ""
+  echo "  Valid book argument values are:"
+  cd $DOCS_SRC
+  subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "topics" ! -iname "images" ! -iname "scripts" | sort`
+  for subdir in $subdirs
+  do
+    echo "   ${subdir##*/}"
+  done
+  echo ""
+  # Return to where we started as a courtesy.
+  cd $CURRENT_DIR
+}
+
+OPTIND=1
+while getopts "h" c
+ do
+     case "$c" in
+       h)         usage
+                  exit 1;;
+       \?)        echo "Unknown option: -$OPTARG." >&2
+                  usage
+                  exit 1;;
+     esac
+ done
+shift $(($OPTIND - 1))
+
+# Use $DOCS_SRC so we don't have to worry about relative paths.
+cd $DOCS_SRC
+
+# Set the list of docs to build to whatever the user passed in (if anyting)
+subdirs=$@
+if [ $# -gt 0 ]; then
+  echo "=== Bulding $@ ==="
+else
+  echo "=== Building all the guides ==="
+  # Recurse through the guide directories and build them.
+  subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "topics" ! -iname "images" ! -iname "scripts" | sort`
+fi
+echo $PWD
+for subdir in $subdirs
+do
+  echo "Building $DOCS_SRC/${subdir##*/}"
+  # Navigate to the dirctory and build it
+  if ! [ -e $DOCS_SRC/${subdir##*/} ]; then
+    BUILD_MESSAGE="$BUILD_MESSAGE\nERROR: $DOCS_SRC/${subdir##*/} does not exist."
+    # This is a book argument error so we should list the valid arguments.
+    LIST_BOOKS="true"
+    continue
+  fi
+  cd $DOCS_SRC/${subdir##*/}
+  GUIDE_NAME=${PWD##*/}
+  python gitlab-conversion.py
+  ./buildGuide.sh
+
+  if [ "$?" = "1" ]; then
+    BUILD_ERROR="ERROR: Build of $GUIDE_NAME failed. See the log above for details."
+    BUILD_MESSAGE="$BUILD_MESSAGE\n$BUILD_ERROR"
+  fi
+
+  # Return to the parent directory
+  cd $SCRIPT_SRC
+done
+
+# Return to where we started as a courtesy.
+cd $CURRENT_DIR
+
+# Report any errors
+echo ""
+if [ "$BUILD_MESSAGE" == "$BUILD_RESULTS" ]; then
+  echo "Build was successful!"
+else
+  echo -e "${RED}$BUILD_MESSAGE${NO_COLOR}"
+  if [ "$LIST_BOOKS" ]; then
+    listvalidbooks
+  else
+    # This is a build error.
+    echo -e "${RED}Please fix all issues before requesting a merge!${NO_COLOR}"
+  fi
+fi
+exit;

--- a/securing_apps/buildGuide.sh
+++ b/securing_apps/buildGuide.sh
@@ -27,6 +27,10 @@ while getopts "ht:" c
      esac
 done
 
+echo ""
+echo "********************************************"
+echo " Building $CURRENT_GUIDE                    "
+echo "********************************************"
 if [ ! -d target ]; then
    echo "You must run 'python gitlab-conversion.py' to convert the content before you run this script."
    exit
@@ -34,9 +38,15 @@ fi
 
 # Remove the guide directory path from the master.adoc file as it is not needed
 echo ""
+echo "***************************************************************************************"
 echo "Removing the guide directory path from the master.adoc file as it is not needed."
-echo "NOTE: This should really be done in the Python script!"
-find . -name 'master.adoc' -print | xargs sed -i 's/include::securing_apps\//include::/g'
+echo "NOTE: The guide directory path should probably be removed from the SUMMARY.adoc file,"
+echo "but since we do not know if it will break the upstream build, we are doing this here. "
+echo "If it can not be removed from the SUMMARY.adoc file, this should really be done in the "
+echo "Python script because otherwise you must run this script before porting content!"
+echo "***************************************************************************************"
+echo ""
+find . -name 'master.adoc' -print | xargs sed -i "s/include::$CURRENT_GUIDE\//include::/g"
 
 # Remove the html and build directories and then recreate the html/images/ directory
 if [ -d target/html ]; then
@@ -49,11 +59,6 @@ fi
 mkdir -p html
 cp -r target/images/ target/html/
 
-echo ""
-echo "********************************************"
-echo " Building $CURRENT_GUIDE                "
-echo "********************************************"
-echo ""
 echo "Building an asciidoctor version of the guide"
 asciidoctor -t -dbook -a toc -o target/html/$CURRENT_GUIDE.html target/master.adoc
 

--- a/server_admin/buildGuide.sh
+++ b/server_admin/buildGuide.sh
@@ -27,6 +27,10 @@ while getopts "ht:" c
      esac
 done
 
+echo ""
+echo "********************************************"
+echo " Building $CURRENT_GUIDE                    "
+echo "********************************************"
 if [ ! -d target ]; then
    echo "You must run 'python gitlab-conversion.py' to convert the content before you run this script."
    exit
@@ -34,9 +38,15 @@ fi
 
 # Remove the guide directory path from the master.adoc file as it is not needed
 echo ""
+echo "***************************************************************************************"
 echo "Removing the guide directory path from the master.adoc file as it is not needed."
-echo "NOTE: This should really be done in the Python script!"
-find . -name 'master.adoc' -print | xargs sed -i 's/include::securing_apps\//include::/g'
+echo "NOTE: The guide directory path should probably be removed from the SUMMARY.adoc file,"
+echo "but since we do not know if it will break the upstream build, we are doing this here. "
+echo "If it can not be removed from the SUMMARY.adoc file, this should really be done in the "
+echo "Python script because otherwise you must run this script before porting content!"
+echo "***************************************************************************************"
+echo ""
+find . -name 'master.adoc' -print | xargs sed -i "s/include::$CURRENT_GUIDE\//include::/g"
 
 # Remove the html and build directories and then recreate the html/images/ directory
 if [ -d target/html ]; then
@@ -49,11 +59,6 @@ fi
 mkdir -p html
 cp -r target/images/ target/html/
 
-echo ""
-echo "********************************************"
-echo " Building $CURRENT_GUIDE                "
-echo "********************************************"
-echo ""
 echo "Building an asciidoctor version of the guide"
 asciidoctor -t -dbook -a toc -o target/html/$CURRENT_GUIDE.html target/master.adoc
 

--- a/server_development/buildGuide.sh
+++ b/server_development/buildGuide.sh
@@ -27,6 +27,10 @@ while getopts "ht:" c
      esac
 done
 
+echo ""
+echo "********************************************"
+echo " Building $CURRENT_GUIDE                    "
+echo "********************************************"
 if [ ! -d target ]; then
    echo "You must run 'python gitlab-conversion.py' to convert the content before you run this script."
    exit
@@ -34,9 +38,15 @@ fi
 
 # Remove the guide directory path from the master.adoc file as it is not needed
 echo ""
+echo "***************************************************************************************"
 echo "Removing the guide directory path from the master.adoc file as it is not needed."
-echo "NOTE: This should really be done in the Python script!"
-find . -name 'master.adoc' -print | xargs sed -i 's/include::securing_apps\//include::/g'
+echo "NOTE: The guide directory path should probably be removed from the SUMMARY.adoc file,"
+echo "but since we do not know if it will break the upstream build, we are doing this here. "
+echo "If it can not be removed from the SUMMARY.adoc file, this should really be done in the "
+echo "Python script because otherwise you must run this script before porting content!"
+echo "***************************************************************************************"
+echo ""
+find . -name 'master.adoc' -print | xargs sed -i "s/include::$CURRENT_GUIDE\//include::/g"
 
 # Remove the html and build directories and then recreate the html/images/ directory
 if [ -d target/html ]; then
@@ -49,11 +59,6 @@ fi
 mkdir -p html
 cp -r target/images/ target/html/
 
-echo ""
-echo "********************************************"
-echo " Building $CURRENT_GUIDE                "
-echo "********************************************"
-echo ""
 echo "Building an asciidoctor version of the guide"
 asciidoctor -t -dbook -a toc -o target/html/$CURRENT_GUIDE.html target/master.adoc
 

--- a/server_installation/buildGuide.sh
+++ b/server_installation/buildGuide.sh
@@ -27,6 +27,10 @@ while getopts "ht:" c
      esac
 done
 
+echo ""
+echo "********************************************"
+echo " Building $CURRENT_GUIDE                    "
+echo "********************************************"
 if [ ! -d target ]; then
    echo "You must run 'python gitlab-conversion.py' to convert the content before you run this script."
    exit
@@ -34,9 +38,15 @@ fi
 
 # Remove the guide directory path from the master.adoc file as it is not needed
 echo ""
+echo "***************************************************************************************"
 echo "Removing the guide directory path from the master.adoc file as it is not needed."
-echo "NOTE: This should really be done in the Python script!"
-find . -name 'master.adoc' -print | xargs sed -i 's/include::securing_apps\//include::/g'
+echo "NOTE: The guide directory path should probably be removed from the SUMMARY.adoc file,"
+echo "but since we do not know if it will break the upstream build, we are doing this here. "
+echo "If it can not be removed from the SUMMARY.adoc file, this should really be done in the "
+echo "Python script because otherwise you must run this script before porting content!"
+echo "***************************************************************************************"
+echo ""
+find . -name 'master.adoc' -print | xargs sed -i "s/include::$CURRENT_GUIDE\//include::/g"
 
 # Remove the html and build directories and then recreate the html/images/ directory
 if [ -d target/html ]; then
@@ -49,11 +59,6 @@ fi
 mkdir -p html
 cp -r target/images/ target/html/
 
-echo ""
-echo "********************************************"
-echo " Building $CURRENT_GUIDE                "
-echo "********************************************"
-echo ""
 echo "Building an asciidoctor version of the guide"
 asciidoctor -t -dbook -a toc -o target/html/$CURRENT_GUIDE.html target/master.adoc
 


### PR DESCRIPTION
@jenmalloy : The getting_started book builds with asciidoctor but does not build with ccutil. It didn't build before these updates either. One thing I noticed is that it doesn't have a book-title defined in the SUMMARY.adoc file. 

To build all the books, navigate to the root of the keycloak-documentation directory and type: 

    $ scripts/buildGuides.sh
