### PR TITLE
Modify authorization_services book-product.json variables for the 

### DIFF
--- a/authorization_services/book-product.json
+++ b/authorization_services/book-product.json
@@ -26,11 +26,15 @@
       "doc_base_url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
       "doc_info_version_url": "7.1"
     },
+    "adapterguide": {
+      "name": "Securing Applications and Services Guide",
+      "link": "https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.1-beta/html-single/securing_applications_and_services_guide/"
+    },
     "keycloakjsadapter": {
       "name": "JavaScript OpenID Connect Adapter",
       "link": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/7.1-beta/html-single/securing-applications-and-services-guide#javascript_adapter"
     },
-    "keycloakgettingstarted": {
+    "gettingstarted": {
       "name": "Getting Started",
       "link": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/7.1-beta/html/getting-started-guide/"
     },

--- a/authorization_services/topics/getting-started/overview.adoc
+++ b/authorization_services/topics/getting-started/overview.adoc
@@ -2,7 +2,7 @@
 == Getting Started
 
 Before you can participate in this tutorial, you need to complete the installation of {{book.project.name}} and create the
-initial admin user as shown in the link:{{book.keycloakgettingstarted.link}}[{{book.keycloakgettingstarted.name}}] tutorial.
+initial admin user as shown in the link:{{book.gettingstarted.link}}[{{book.gettingstarted.name}}] tutorial.
 There is one caveat to this.  You have to run a separate {{book.appServer}} instance on the same machine as the
 {{book.project.name}} server.  This separate instance will run your Java Servlet application.  Because of this you will
 have to run the {{book.project.name}} under a different port so that there are no port conflicts when running on the
@@ -23,7 +23,7 @@ $ ${KEYCLOAK_SERVER_DIR}/bin/standalone.sh -Djboss.socket.binding.port-offset=10
 > ${KEYCLOAK_SERVER_DIR}\bin\standalone.bat -Djboss.socket.binding.port-offset=100
 ----
 
-For more details about how to install and configure a {{book.appServer}}, please follow the steps on the link:{{book.keycloakinstallclientadapter.link}}[{{book.keycloakinstallclientadapter.name}}] tutorial.
+For more details about how to install and configure a {{book.appServer}}, please follow the steps on the link:{{book.adapterguide.link}}[{{book.adapterguide.name}}] tutorial.
 
 After installing and booting both servers you should be able to access {{book.project.name}} Admin Console at http://localhost:8180/auth/admin/ and also the {{book.appServer}} instance at
 http://localhost:8080.


### PR DESCRIPTION
getting started and adapter guide book names to match those used in the community guide versions.