### PR TITLE
Fixed typos about technical term

### DIFF
--- a/server_admin/topics/sessions/timeouts.adoc
+++ b/server_admin/topics/sessions/timeouts.adoc
@@ -35,7 +35,7 @@ Let's walk through each of the items on this page.
 |With the Implicit Flow no refresh token is provided. For this reason there's a separate timeout for access tokens created with the Implicit Flow.
 
 |Client login timeout
-|This is the maximum time that a client has to finish the Authentication Code Flow in OIDC.
+|This is the maximum time that a client has to finish the Authorization Code Flow in OIDC.
 
 |Login timeout
 |Total time a login must take.  If authentication takes longer than this time then the user will have to start the authentication process over.

--- a/server_admin/topics/threat/compromised-codes.adoc
+++ b/server_admin/topics/threat/compromised-codes.adoc
@@ -1,9 +1,9 @@
 
-=== Compromised Access Codes
+=== Compromised Authorization Code
 
-For the <<fake/../../sso-protocols/oidc.adoc#_oidc-auth-flows, OIDC Auth Code Flow>>, it would be very hard for an attacker to compromise {{book.project.name}} access codes.
-{{book.project.name}} generates a cryptographically strong random value for its access codes so it would be very hard to guess an access token.
-An access code can only be used once to obtain an access token.
-In the admin console you can specify how long an access token is valid for on the <<fake/../../sessions/timeouts.adoc#_timeouts, timeouts page>>.
+For the <<fake/../../sso-protocols/oidc.adoc#_oidc-auth-flows, OIDC Auth Code Flow>>, it would be very hard for an attacker to compromise {{book.project.name}} authorization codes.
+{{book.project.name}} generates a cryptographically strong random value for its authorization codes so it would be very hard to guess an access token.
+An authorization code can only be used once to obtain an access token.
+In the admin console you can specify how long an authorization code is valid for on the <<fake/../../sessions/timeouts.adoc#_timeouts, timeouts page>>.
 This value should be really short, as short as a few seconds and just long enough for the client to make the request to obtain a token from the code.
 


### PR DESCRIPTION
Fixed some typos about technical term in Compromised Access Codes  and Session and Token Timeouts.