### PR TITLE
KEYCLOAK-4208: update documentation to reflect implementation change

### DIFF
--- a/securing_apps/topics/oidc/java/spring-boot-adapter.adoc
+++ b/securing_apps/topics/oidc/java/spring-boot-adapter.adoc
@@ -64,12 +64,12 @@ Here's an example configuration:
 ----
 
 
+keycloak.securityConstraints[0].authRoles[0] = admin
+keycloak.securityConstraints[0].authRoles[1] = user
 keycloak.securityConstraints[0].securityCollections[0].name = insecure stuff
-keycloak.securityConstraints[0].securityCollections[0].authRoles[0] = admin
-keycloak.securityConstraints[0].securityCollections[0].authRoles[1] = user
 keycloak.securityConstraints[0].securityCollections[0].patterns[0] = /insecure
 
-keycloak.securityConstraints[0].securityCollections[1].name = admin stuff
-keycloak.securityConstraints[0].securityCollections[1].authRoles[0] = admin
-keycloak.securityConstraints[0].securityCollections[1].patterns[0] = /admin
+keycloak.securityConstraints[1].authRoles[0] = admin
+keycloak.securityConstraints[1].securityCollections[0].name = admin stuff
+keycloak.securityConstraints[1].securityCollections[0].patterns[0] = /admin
 ----


### PR DESCRIPTION
This is the documentation change to reflect changes in https://github.com/keycloak/keycloak/pull/3838. The newly configured structure has been tested here https://github.com/ahus1/slackspace-angular-spring-keycloak/tree/KEYCLOAK-4208a