### PR TITLE
Add asciidoc-admonition-icons GitBook plugin.

### DIFF
--- a/book.json
+++ b/book.json
@@ -7,7 +7,8 @@
     "toggle-chapters",
     "ungrey",
     "splitter",
-    "ga"
+    "ga",
+    "asciidoc-admonition-icons"
   ],
   "pluginsConfig": {
     "ga": {

--- a/server_development/book.json
+++ b/server_development/book.json
@@ -6,7 +6,8 @@
   "plugins": [
     "toggle-chapters",
     "ungrey",
-    "splitter"
+    "splitter",
+    "asciidoc-admonition-icons"
   ],
   "variables": {
     "title": "Server Developer Guide",


### PR DESCRIPTION
I recently wrote a plugin that reintroduces the missing font icons for AsciiDoc admonition blocks. I made some enhancements a few days ago to support GitBook 2.x.x.

Please have a play around and see what you think :-). A bunch of customisations are available if you're so inclined: https://github.com/msavy/gitbook-plugin-asciidoc-admonition-icons#configuration

LMK if I should apply it to any other branches.

Here are some screenshots:

![image](https://cloud.githubusercontent.com/assets/423513/26279287/73268dc4-3da7-11e7-81ee-4c293786b7ea.png)

![image](https://cloud.githubusercontent.com/assets/423513/26279297/ac12111c-3da7-11e7-94b7-7bdd941f11e5.png)

![image](https://cloud.githubusercontent.com/assets/423513/26279299/b71586ca-3da7-11e7-94eb-70740045cc6a.png)


