### PR TITLE
KEYCLOAK-4980 SAML adapter should return 401 when unauthenticated Aja…

### DIFF
--- a/securing_apps/topics/saml/java/general-config.adoc
+++ b/securing_apps/topics/saml/java/general-config.adoc
@@ -16,7 +16,8 @@ This is what one might look like:
         logoutPage="/logout.jsp"
         forceAuthentication="false"
         isPassive="false"
-        turnOffChangeSessionIdOnLogin="false">
+        turnOffChangeSessionIdOnLogin="false"
+        autodetectBearerOnly="false">
         <Keys>
             <Key signing="true" >
                 <KeyStore resource="/WEB-INF/keystore.jks" password="store123">

--- a/securing_apps/topics/saml/java/general-config/sp_element.adoc
+++ b/securing_apps/topics/saml/java/general-config/sp_element.adoc
@@ -10,7 +10,8 @@ Here is the explanation of the SP element attributes:
     sslPolicy="ssl"
     nameIDPolicyFormat="format"
     forceAuthentication="true"
-    isPassive="false">
+    isPassive="false"
+    autodetectBearerOnly="false">
 ...
 </SP>
 ----
@@ -49,3 +50,9 @@ turnOffChangeSessionIdOnLogin::
   Change this to `true` to disable this.  It is recommended you do not turn it off.
   Default value is `false`.
 
+autodetectBearerOnly::
+  This should be set to __true__ if your application serves both a web application and web services (e.g. SOAP or REST).
+  It allows you to redirect unauthenticated users of the web application to the Keycloak login page,
+  but send an HTTP `401` status code to unauthenticated SOAP or REST clients instead as they would not understand a redirect to the login page.
+  Keycloak auto-detects SOAP or REST clients based on typical headers like `X-Requested-With`, `SOAPAction` or `Accept`.
+  The default value is _false_.


### PR DESCRIPTION
…x client accesses
to comply with the request in the PR [4192](https://github.com/keycloak/keycloak/pull/4192)