### PR TITLE
Add overrides to asciidoctor's CSS so it looks more like keycloak.org

### DIFF
--- a/aggregation/navbar-head.html
+++ b/aggregation/navbar-head.html
@@ -3,7 +3,6 @@
 
 ul#globalnav {
     background-color: #ededed;
-    font-family: "Open Sans","DejaVu Sans",sans-serif;
 
     list-style: none;
     width: 100%;
@@ -76,6 +75,39 @@ body.toc2 {
     body.toc2 {
         padding-top: 48px;
     }
+}
+
+</style>
+
+<style>
+/* General Changes */
+
+h1, h2, h3, #toctitle, .sidebarblock>.content>.title, h4, h5, h6 {
+    color: #444444;
+    font-weight: 500;
+}
+
+a {
+    color: #004670;
+    text-decoration: none;
+}
+
+a:hover {
+    color: #7da1dc;
+}
+
+body {
+    font-family: "Open Sans","DejaVu Sans",sans-serif;
+    color: #444444;
+}
+
+.subheader, .admonitionblock td.content>.title, .audioblock>.title, .exampleblock>.title, .imageblock>.title, .listingblock>.title, .literalblock>.title, .stemblock>.title, .openblock>.title, .paragraph>.title, .quoteblock>.title, table.tableblock>.title, .verseblock>.title, .videoblock>.title, .dlist>.title, .olist>.title, .ulist>.title, .qlist>.title, .hdlist>.title {
+    color: #444444;
+}
+
+.admonitionblock td.content>.title, .audioblock>.title, .exampleblock>.title, .imageblock>.title, .listingblock>.title, .literalblock>.title, .stemblock>.title, .openblock>.title, .paragraph>.title, .quoteblock>.title, table.tableblock>.title, .verseblock>.title, .videoblock>.title, .dlist>.title, .olist>.title, .ulist>.title, .qlist>.title, .hdlist>.title {
+    font-family: "Open Sans","DejaVu Sans",sans-serif;
+    font-style: normal;
 }
 
 </style>


### PR DESCRIPTION
Not a complete restyle, but at least the colours and fonts match better.

I appended the overrides onto `navbar-head.html`. I would have preferred a separate file, but asciidoctor doesn't accept more than one common `docinfo.html` file.