### PR TITLE
Matthew Helmke edits for Red Hat writing assessment

### DIFF
--- a/server_admin/topics/realms/master.adoc
+++ b/server_admin/topics/realms/master.adoc
@@ -1,15 +1,23 @@
 
 === The Master Realm
 
-When you boot {project_name} for the first time a pre-defined realm is created for you.  This initial realm is called
-the _master_ realm and is the king of all realms.  Admins in this realm have permissions to view and manage any
-other realm created on the server instance.  When you define your initial admin account, you are creating an account in the _master_ realm.
-Your initial login to the admin console will also be through the _master_ realm.
+When you boot {project_name} for the first time {project_name} creates a
+pre-defined realm for you. This initial realm is the _master_ realm. It is the
+highest level in the hierarchy of realms. Admin accounts in this realm have
+permissions to view and manage any other realm created on the server instance.
+When you define your initial admin account, you create an account in the
+_master_ realm. Your initial login to the admin console will also be via the
+_master_ realm.
 
-It is recommended that you do not use the _master_ realm to manage the users and applications in your organization.  Keep the _master_ realm
-as a place for _super_ admins to create and manage the realms in your system.  This keeps things clean and organized.
+Red Hat recommends that you do not use the _master_ realm to manage the users
+and applications in your organization. Reserve use of the _master_ realm for
+_super_ admins to create and manage the realms in your system. Following this
+security model helps prevent accidental changes and follows the tradition
+of permitting user accounts access to only those privileges and powers necessary
+for the successful completion of their current task.
 
-It is possible to disable the _master_ realm and define admin accounts at each individual new realm you create.  Each realm has its own
-dedicated Admin Console that you can log into with local accounts.  This guide talks more about this in the
-<<_per_realm_admin_permissions, Dedicated Realm Admin Consoles>>
+It is possible to disable the _master_ realm and define admin accounts within
+each individual new realm you create. Each realm has its own dedicated Admin
+Console that you can log into with local accounts. This guide talks more about
+this in the <<_per_realm_admin_permissions, Dedicated Realm Admin Consoles>>
 chapter.

--- a/server_admin/topics/realms/master.adoc
+++ b/server_admin/topics/realms/master.adoc
@@ -9,7 +9,7 @@ When you define your initial admin account, you create an account in the
 _master_ realm. Your initial login to the admin console will also be via the
 _master_ realm.
 
-Red Hat recommends that you do not use the _master_ realm to manage the users
+We recommend that you do not use the _master_ realm to manage the users
 and applications in your organization. Reserve use of the _master_ realm for
 _super_ admins to create and manage the realms in your system. Following this
 security model helps prevent accidental changes and follows the tradition


### PR DESCRIPTION
I have not read any style guide in use for files in the repo, so I made a decision that could be controversial along with the text edits. Specifically, I chose to narrow the margins within the file for easier viewing while editing across all text editors. The right margin does not affect the Markdown processors  I have used, all of which ignore CRs and format text into paragraphs based on an empty white line. I hope that is also the case here with asciidoc.

Other changes include:
* Removing double spaces between sentences
* Changing passive voice to active
* Expanding the reasoning given for limiting use of the master realm
* Changing some phrasing in favor of expressions that I thought sounded closer to a standard in technical documentation, such as replacing "king of all realms" to "the highest level in the hierarchy of realms"