### PR TITLE
Adding a statement about the need to add the 'username' of the newly created user in the host-slave.xml

### DIFF
--- a/server_installation/topics/operating-mode/domain.adoc
+++ b/server_installation/topics/operating-mode/domain.adoc
@@ -269,6 +269,13 @@ Now cut and paste the secret value into the _.../domain/configuration/host-slave
                  </server-identities>
 ----
 
+You will also need to add the _username_ of the created user in the _.../domain/configuration/host-slave.xml_ file:
+
+[source,xml]
+----
+     <remote security-realm="ManagementRealm" username="admin">
+----
+
 ===== Run the Boot Scripts
 
 Since we're simulating a two node cluster on one development machine, you'll run the boot script twice:


### PR DESCRIPTION
The 'Setup Slave Connection to Domain Controller' topic of the Server Installation and Configuration guide doesn't mention about the need to add the username of the newly created user to the xml file of the slave. Without this, the connection cannot be complete. I have added the step for the same. 