### PR TITLE
[KEYCLOAK-5471] X.509 Auth - email mapping doesn't work when 'Login with email' is disabled in the Realm

### DIFF
--- a/server_admin/topics/authentication/x509.adoc
+++ b/server_admin/topics/authentication/x509.adoc
@@ -38,7 +38,9 @@ The regular expression filtering is applicable only if the `Identity Source` is 
 
 #### Mapping certificate identity to an existing user
 
-The certificate identity mapping can be configured to map the extracted user identity to an existing user's username or e-mail or to a custom attribute which value matches the certificate identity. For example, setting the `Identity source` to _Subject's e-mail_ and `User mapping method` to _Username or email_ will have the X.509 client certificate authenticator use the e-mail attribute in the certificate's Subject DN  as a search criteria to look up an existing user by username or by e-mail.
+The certificate identity mapping can be configured to map the extracted user identity to an existing user's username or e-mail or to a custom attribute which value matches the certificate identity. For example, setting the `Identity source` to _Subject's e-mail_ and `User mapping method` to _Username or email_ will have the X.509 client certificate authenticator use the e-mail attribute in the certificate's Subject DN  as a search criteria to look up an existing user by username or by e-mail. 
+
+IMPORTANT: Please notice that if we disable `Login with email` at realm settings, the same rules will be applied to certificate authentication. In other words, users won't be able to log in using e-mail attribute. 
 
 #### Other Features: Extended Certificate Validation
 - Revocation status checking using CRL


### PR DESCRIPTION
This change only documents the behavior of certificate authentication
when *Login with email* is disabled. In this way people don't get
confused about it.