### PR TITLE
first complete edit of the Chapter 6, Client Registration CLI

### DIFF
--- a/securing_apps/topics/client-registration/client-registration-cli.adoc
+++ b/securing_apps/topics/client-registration/client-registration-cli.adoc
@@ -1,194 +1,179 @@
 [[_client_registration_cli]]
 == Client Registration CLI
 
-`Client Registration CLI` is a command line interface tool for application developers to configure new clients in self-service manner
-when integrating with {project_name}. It is specifically designed to interact with {project_name} Client Registration REST endpoints.
+The Client Registration CLI is a command-line interface (CLI) tool for application developers to configure new clients in a self-service manner when integrating with {project_name}. It is specifically designed to interact with {project_name} Client Registration REST endpoints.
 
-In order for any application to be able to use {project_name} it is necessary to create or obtain a client configuration. Usually a new client is configured for
-each new application hosted on a unique hostname. When application interacts with {project_name} it needs to identify itself with a `client_id` in order for {project_name}
-to be able to provide login page, SSO session management, and other services.
+It is necessary to create or obtain a client configuration for any application to be able to use {project_name}. You usually configure a new client for each new application hosted on a unique host name. When an application interacts with {project_name}, the application identifies itself with a client ID so {project_name} can provide a login page, single sign-on (SSO) session management, and other services.
 
-`Client Registration CLI` allows you to configure application clients from a command line, and can be used in shell scripts as well.
+You can configure application clients from a command line with the Client Registration CLI, and you can use it in shell scripts.
 
-To allow a particular user to use `Client Registration CLI` the {project_name} administrator will typically use `Admin Console` to configure
- a new user with proper roles, or configure a new client and client secret to grant access to `Client Registration REST API`.
+The {project_name} administrator typically uses the Admin Console to allow a particular user to use the Client Registration CLI to configure a new user with proper roles or configure a new client and a client secret to grant access to the Client Registration REST API.
 
 
 [[_configuring_a_user_for_client_registration_cli]]
 === Configuring a new regular user for use with Client Registration CLI
 
-Login as `admin` into `Admin Console` (e.g. `http://localhost:8080/auth/admin`). Select a realm you want to administer.
-If you want to use existing user, select that user for edit, otherwise create a new user. Go to `Role Mappings` tab. Under
-`Client Roles` select `realm-management` (if in master realm, select `NAME-realm` where NAME is name of the target realm - users in master realm can have access to any other realms).
-Under `Available Roles` select `manage-client` for full set of client management permissions. Alternatively you can choose
-`view-clients` for read-only or `create-client` for ability to create new clients.
-These permissions grant user the capability to perform operations without the use of <<_initial_access_token,Initial Access Token>> or
-<<_registration_access_token,Registration Access Token>>.
+. Log in to the Admin Console (for example, http://localhost:8080/auth/admin) as [command]`admin`.
+. Select a realm to administer.
+. If you want to use an existing user, select that user to edit; otherwise, create a new user.
+. Select *Role Mappings > Client Roles > realm-management*. If you are in the master realm, select *NAME-realm*, where `NAME` is the name of the target realm. You can grant access to any other realm to users in the master realm.
+. Select *Available Roles > manage-client* to display a full set of client management permissions. Another option is to choose *view-clients* for read-only or *create-client* to create new clients.
++
+[NOTE]
+====
+These permissions grant the user the capability to perform operations without the use of <<_initial_access_token,Initial Access Token>> or <<_registration_access_token,Registration Access Token>>.
+====
 
-It's possible to not assign users any of `realm-management` roles. In that case user can still login with `Registration Client CLI`
-but will not be able to use it without being in possession of an `Initial Access Token`. Trying to perform any operations
-without it will result in `403 Forbidden` error.
+It is possible to not assign any [command]`realm-management` roles to a user. In that case, a user can still log in with the Registration Client CLI but cannot use it without an Initial Access Token. Trying to perform any operations without a token results in a *403 Forbidden* error.
 
-Administrator can issue `Initial Access Tokens` from `Admin Console` by selecting `Client Registration` tab under `Realm Settings`, then `Initial Access Token` sub-tab.
+The Administrator can issue Initial Access Tokens from the Admin Console through the *Realm Settings > Client Registration > Initial Access Token* menu.
+
 
 [[_configuring_a_client_for_use_with_client_registration_cli]]
-=== Configuring a client for use with Client Registration CLI
+=== Configuring a client for use with the Client Registration CLI
 
-By default the `Client Registration CLI` identifies to the server as `admin-cli` client which is automatically configured for every new realm.
-No additional client configuration is necessary when logging in with username. You may wish to strengthen security by
-configuring the client `Access Type` as `Confidential`, and under `Credentials` tab select `ClientId and Secret`. When
-running `kcreg config credentials` you would then also have to provide a secret by using `--secret` option.
+By default, the server recongizes the Client Registration CLI as the [filename]`admin-cli` client, which is configured automatically for every new realm. No additional client configuration is necessary when logging in with a user name.
 
-If you want to use a separate client configuration for `Registration Client CLI` then you can create a new client - you can call it `reg-cli`
-for example. When running `kcreg config credentials` you then need to specify which `clientId` to use e.g. `--client reg-cli`.
+. Strengthen the security by configuring the client [filename]`Access Type` as [filename]`Confidential` and selecting *Credentials > ClientId and Secret*.
+. Provide a secret when running [command]`kcreg config credentials` by using the [command]`--secret` option.
+. Create a new client (for example, [filename]`reg-cli`) if you want to use a separate client configuration for the Registration Client CLI.
+. Specify which [filename]`clientId` to use (for example, [command]`--client reg-cli`) when running [command]`kcreg config credentials`.
+. Enable service accounts if you want to use a service account associated with the client by selecting a client to edit in the *Clients* section of the `Admin Console`.
+. Under *Settings*, change the *Access Type* to *Confidential*, toggle the *Service Accounts Enabled* setting to *On*, and click [btn]`Save`.
++
+[NOTE]
+====
+You can configure either [filename]`Client Id and Secret` or [filename]`Signed JWT` under the *Credentials* tab .
+====
+. You can omit specifying the user when running [command]`kcreg config credentials` and only provide the client secret or keystore information.
 
-If you want to use a service account associated with the client, you first need to enable service accounts. In `Admin Console`
-go to `Clients` section, and select a client for edit. Then under `Settings` change the `Access Type` to `Confidential`, and toggle
-`Service Accounts Enabled` setting to `On`. Make sure to `Save` the configuration.
-
-Under `Credentials` tab you can choose to configure either `Client Id and Secret`, or `Signed JWT`.
-
-Having done that you can then omit specifying user during `kcreg config credentials`, and only provide client secret or keystore info.
 
 [[_installing_client_registration_cli]]
-=== Installing Client Registration CLI
+=== Installing the Client Registration CLI
 
-Client Registration CLI is packaged inside Keycloak Server distribution. You can find execution scripts inside `bin` directory.
+The Client Registration CLI is packaged inside the Keycloak Server distribution. You can find execution scripts inside the [filename]`bin` directory. The Linux script is called [filename]`kcreg.sh`, and the Windows script is called [filename]`kcreg.bat`.
 
-The Linux script is called `kcreg.sh`, and the one for Windows is called `kcreg.bat`.
+Add the Keycloak server directory to your [filename]`PATH` when setting up the client for use from any location on the file system .
 
-In order to setup the client for use from any location on the filesystem you may want to add Keycloak server directory to your PATH.
+For example, on:
 
-On Linux:
-[source,bash]
+* Linux:
+[options="npwrap"]
 ----
 $ export PATH=$PATH:$KEYCLOAK_HOME/bin
 $ kcreg.sh
 ----
-
-On Windows:
-[source,bash]
+* Windows:
+[options="npwrap"]
 ----
 c:\> set PATH=%PATH%;%KEYCLOAK_HOME%\bin
 c:\> kcreg
 ----
 
-Where KEYCLOAK_HOME refers to a directory where Keycloak Server distribution was unpacked.
+[filename]`KEYCLOAK_HOME` refers to a directory where the Keycloak Server distribution was unpacked.
 
 
 [[_using_client_registration_cli]]
-=== Using Client Registration CLI
+=== Using the Client Registration CLI
 
-First you need to start an authenticated session (i.e. logging in) by providing credentials. Then you perform operations on Client Registration REST endpoint.
+. Start an authenticated session by logging in with your credentials.
+. Run commands on the [filename]`Client Registration REST` endpoint.
++
+For example, on:
 
-For example on Linux:
-
-[source,bash]
+* Linux:
++
+[options="npwrap"]
 ----
 $ kcreg.sh config credentials --server http://localhost:8080/auth --realm demo --user user --client reg-cli
 $ kcreg.sh create -s clientId=my_client -s 'redirectUris=["http://localhost:8980/myapp/*"]'
 $ kcreg.sh get my_client
 ----
-
-Or on Windows:
-
-[source,bash]
+* Windows:
++
+[options="npwrap"]
 ----
 c:\> kcreg config credentials --server http://localhost:8080/auth --realm demo --user user --client reg-cli
 c:\> kcreg create -s clientId=my_client -s "redirectUris=[\"http://localhost:8980/myapp/*\"]"
 c:\> kcreg get my_client
 ----
++
+[NOTE]
+====
+In a production environment, Keycloak has to be accessed with [filename]`https:` to avoid exposing tokens to network sniffers.
+====
+. If a server's certificate is not issued by one of the trusted certificate authorities (CAs) that are included in Java's default certificate truststore, prepare a [filename]`truststore.jks` file and instruct the Client Registration CLI to use it.
++
+For example, on:
 
-
-In a production environment Keycloak has to be accessed with `https:` to avoid exposing tokens to network sniffers. If server's
-certificate is not issued by one of the trusted CAs that are included in Java's default certificate truststore, you will
-need to prepare a truststore.jks file, and instruct `Client Registration CLI` to use it.
-
-For example on Linux:
-[source,bash]
+* Linux:
++
+[options="npwrap"]
 ----
 $ kcreg.sh config truststore --trustpass $PASSWORD ~/.keycloak/truststore.jks
 ----
-
-Or on Windows:
-
-[source,bash]
+* Windows:
++
+[options="npwrap"]
 ----
 c:\> kcreg config truststore --trustpass %PASSWORD% %HOMEPATH%\.keycloak\truststore.jks
 ----
 
 
 [[_logging_in]]
-==== Logging In
+==== Logging in
 
-When logging in with `Client Registration CLI` you specify a server endpoint url, and a realm. Then you specify a username
-or, alternatively, a client id, which will result in special service account being used. In the first case,
-a password for the specified user has to be used at login. In the latter case there is no user password - only client secret
-or a `Signed JWT` is used.
+. Specify a server endpoint URL and a realm when you log in with the Client Registration CLI.
+. Specify a user name or a client ID, which results in a special service account being used. When using a user name, you must use a password for the specified user. When using a client ID, you use a client secret or a [filename]`Signed JWT` instead of a password.
 
-Regardless of the method, the account that logs in needs proper permissions to be able to perform client
-registration operations. Keep in mind that any account in non-master realm can only have permissions to manage clients within the same realm.
-If you need to manage different realms, you can either configure multiple users in different realms, or you can create a single user in `master` realm and
-add it roles for managing clients in different realms.
+Regardless of the login method, the account that logs in needs proper permissions to be able to perform client registration operations. Keep in mind that any account in a non-master realm can only have permissions to manage clients within the same realm. If you need to manage different realms, you can either configure multiple users in different realms, or you can create a single user in the [filename]`master` realm and add roles for managing clients in different realms.
 
-`Client Registration CLI` by itself does not support configuring users, for that you would need to use `Admin Console`
-web interface or Admin Client CLI command line tool (see link:{adminguide_link}[{adminguide_name}] for more details).
+You cannot configure users with the Client Registration CLI. Use the Admin Console web interface or the Admin Client CLI to configure users. See link:{adminguide_link}[{adminguide_name}] for more details.
 
-When `kcreg` successfully logs in it receives authorization tokens and saves them into private config file so they can be
-used for subsequent invocations. See <<_working_with_alternative_configurations, next chapter>> for more info on configuration file.
+When [filename]`kcreg` successfully logs in, it receives authorization tokens and saves them in a private configuration file so the tokens can be used for subsequent invocations. See <<_working_with_alternative_configurations>> for more information on configuration files.
 
-See built-in help for more information on using `Client Registration CLI`.
+See the built-in help for more information on using the Client Registration CLI.
 
+For example, on:
 
-For example on Linux:
-[source,bash]
+* Linux:
+[options="nowrap"]
 ----
 $ kcreg.sh help
 ----
-
-
-Or on Windows:
-[source,bash]
+* Windows:
+[options="nowrap"]
 ----
 c:\> kcreg help
 ----
 
-See `kcreg config credentials --help` for more information about starting an authenticated session.
-
+See [filename]`kcreg config credentials --help` for more information about starting an authenticated session.
 
 
 [[_working_with_alternative_configurations]]
 ==== Working with alternative configurations
 
-By default, `Client Registration CLI` automatically maintains a configuration file at a default location - `./.keycloak/kcreg.config`
-under user's home directory.
+By default, the Client Registration CLI automatically maintains a configuration file at a default location, [filename]`./.keycloak/kcreg.config`, under the user's home directory. You can use the [command]`--config` option to point to a different file or location to mantain multiple authenticated sessions in parallel. It is the safest way to perform operations tied to a single configuration file from a single thread.
 
-You can always use `--config` option to point to a different file / location. This way you can mantain multiple authenticated
-sessions in parallel. It is safest to perform operations tied to a single config file from a single thread.
+[IMPORTANT]
+====
+Do not make the configuration file visible to other users on the system. The configuration file contains access tokens and secrets that should be kept private.
+====
 
-Make sure to not make the config file visible to other users on the system as it contains access tokens, and secrets that should be kept private.
-
-You may want to avoid storing any secrets at all inside a config file for the price of less convenience and having to do more token requests.
-In that case you can use `--no-config` option with all your commands. You will have to specify all authentication info with each
-`kcreg` invocation.
-
+You might want to avoid storing secrets inside a configuration file by using the [command]`--no-config` option with all of your commands, even thought it is less convenient and requires more token requests to do so. Specify all authentication information with each [command]`kcreg` invocation.
 
 
 [[_initial_access_and_registration_access_tokens]]
 ==== Initial Access and Registration Access Tokens
 
-`Client Registration CLI` can be used by developers who don't have an account configured at Keycloak server they want to use.
-That's possible when realm administrator issues developer an `Initial Access Token`. It is up to realm administrator to decide
-how to issue and distribute these tokens. Admin can limit Initial Access Token's maximum age, and a total number of clients
-that can be created with it. Many Initial Access Tokens can be created, and it's up to realm administrator to distribute them
-to application developers.
+Developers who do not have an account configured at the Keycloak server they want to use can use the Client Registration CLI. That is possible when the realm administrator issues a developer an Initial Access Token. It is up to the realm administrator to decide how to issue and distribute these tokens. The realm administrator can limit the maximum age of the Initial Access Token and the total number of clients that can be created with it. Many Initial Access Tokens can be created; it is up to realm administrator to distribute them to application developers.
 
-Once a developer is in possession of Initial Access Token they can use it to create new clients without authenticating
-with `kcreg config credentials`. Rather, Initial Access Token can be stored in configuration, or specified as part of `kcreg create`
-command.
+Once a developer has an Initial Access Token, the developer can use it to create new clients without authenticating with [command]`kcreg config credentials`. The Initial Access Token can be stored in the configuration file or specified as part of the [command]`kcreg create` command.
 
-For example on Linux:
-[source,bash]
+For example, on:
+
+* Linux:
+[options="nowrap"]
 ----
 $ kcreg.sh config initial-token $TOKEN
 $ kcreg.sh create -s clientId=myclient
@@ -196,14 +181,13 @@ $ kcreg.sh create -s clientId=myclient
 
 or
 
-[source,bash]
+[options="nowrap"]
 ----
 $ kcreg.sh create -s clientId=myclient -t $TOKEN
 ----
 
-
-On Windows:
-[source,bash]
+* Windows:
+[options="nowrap"]
 ----
 c:\> kcreg config initial-token %TOKEN%
 c:\> kcreg create -s clientId=myclient
@@ -211,185 +195,166 @@ c:\> kcreg create -s clientId=myclient
 
 or
 
-[source,bash]
+[options="nowrap"]
 ----
 c:\> kcreg create -s clientId=myclient -t %TOKEN%
 ----
 
+When using an Initial Access Token, the server response includes a newly issued Registration Access Token. Any subsequent operation for that client needs to be performed by authenticating with that token, which is only valid for that client.
 
-When Initial Access Token is used, the server response will include a newly issued Registration Access Token.
-Any subsequent operation for that client needs to be performed by authenticating with that token which is only valid for that client.
+The Client Registration CLI automatically uses its private configuration file to save and use this token with its associated client. As long as the same configuration file is used for all client operations, the developer does not need to authenticate to read, update, or delete a client that was created this way.
 
-`Client Registration CLI` automatically uses its private configuration file to save, and use this token with its associated client.
-As long as the same configuration file is used for all client operations, the developer will not need to
-authenticate in order to read, update, or delete a client that was created this way.
+See <<_client_registration, Client Registration>> for more information about Initial Access and Registration Access Tokens.
 
-
-You can read more about Initial Access and Registration Access Tokens in <<_client_registration,Client Registration chapter>>.
-
-See `kcreg config initial-token --help` and `kcreg config registration-token --help` for more information on how to configure them with `Client Registration CLI`.
-
+Run the [command]`kcreg config initial-token --help` and [command]`kcreg config registration-token --help` commands for more information on how to configure tokens with the Client Registration CLI.
 
 
 [[_performing_crud_operations]]
-==== Creating client configuration
+==== Creating a client configuration
 
-After authenticating with credentials or configuring Initial Access Token, the first operation will usually be to create a new client.
+The first task after authenticating with credentials or configuring an Initial Access Token is usually to create a new client. Often you might want to use a prepared JSON file as a template and set or override some of the attributes.
 
-We've seen the simplest create command already. Often we may want to use a prepared JSON file as a template and set / override
-some of the attributes. For example, here is how you read a JSON file, override any `clientId` it may contain,
-set any other attributes as well, and after successful creation print the configuration to standard output.
+The following example shows how to read a JSON file, override any client ID it may contain, set any other attributes, and print the configuration to a standard output after successful creation.
 
-On Linux:
-[source,bash]
+* Linux:
+[options="nowrap"]
 ----
 $ kcreg.sh create -f client-template.json -s clientId=myclient -s baseUrl=/myclient -s 'redirectUris=["/myclient/*"]' -o
 ----
-
-On Windows:
-[source,bash]
+* Windows:
+[options="nowrap"]
 ----
 C:\> kcreg create -f client-template.json -s clientId=myclient -s baseUrl=/myclient -s "redirectUris=[\"/myclient/*\"]" -o
 ----
 
+Run the [command]`kcreg create --help` for more information about the [command]`kcreg create` command.
 
-See `kcreg create --help` for more information about `kcreg create`.
-
-
-You can use `kcreg attrs` to list available attributes. Keep in mind that many configuration attributes are not checked for
-validity or consistency. It is up to you to specify proper values. Also note that you should not have any `id` fields in your
-template and should not specify them as arguments to `kcreg create`.
+You can use [command]`kcreg attrs` to list available attributes. Keep in mind that many configuration attributes are not checked for validity or consistency. It is up to you to specify proper values. Remember that you should not have any ID fields in your
+template and should not specify them as arguments to the [command]`kcreg create` command.
 
 
-==== Retrieving client configuration
+==== Retrieving a client configuration
 
-You can retrieve an existing client by using `kcreg get`.
+You can retrieve an existing client by using the [command]`kcreg get` command.
 
-For example, on Linux:
-[source,bash]
+For example, on:
+
+* Linux:
+[options="nowrap"]
 ----
 $ kcreg.sh get myclient
 ----
-
-On Windows:
-[source,bash]
+* Windows:
+[options="nowrap"]
 ----
 C:\> kcreg get myclient
 ----
 
+You can also see the client configuration as an adapter configuration file, which you can package with your web application.
 
-You can also get client configuration as adapter configuration file which you can package with your web application.
+For example, on:
 
-For example, on Linux:
-[source,bash]
+* Linux:
+[options="nowrap"]
 ----
 $ kcreg.sh get myclient -e install > keycloak.json
 ----
-
-On Windows:
-[source,bash]
+* Windows:
+[options="nowrap"]
 ----
 C:\> kcreg get myclient -e install > keycloak.json
 ----
 
-See `kcreg get --help` for more information about `kcreg get`.
+Run the [command]`kcreg get --help` command for more information about the [command]`kcreg get` command.
 
-==== Modifying client configuration
 
-There are two modes of updating client configuration.
+==== Modifying a client configuration
 
-One is to submit a complete new state to the server after getting current configuration, saving it into a file, editing it, and posting it back.
+There are two methods for updating a client configuration.
 
-On Linux:
-[source,bash]
+One method submits a complete new state to the server after getting the current configuration, saving it to a file, editing it, and posting it back to the server.
+
+For example, on:
+
+ * Linux:
+[options="nowrap"]
 ----
 $ kcreg.sh get myclient > myclient.json
 $ vi myclient.json
 $ kcreg.sh update myclient -f myclient.json
 ----
-
-On Windows:
-[source,bash]
+* Windows:
+[options="nowrap"]
 ----
 C:\> kcreg get myclient > myclient.json
 C:\> notepad myclient.json
 C:\> kcreg update myclient -f myclient.json
 ----
 
+The second methods fetches the current client, sets or deletes fields on it, and posts it back in one step.
 
-Another way is to fetch current client, set or delete fields on it, and post it back all in one single step.
+For example, on:
 
-For example, on Linux:
-[source,bash]
+* Linux:
+[options="nowrap"]
 ----
 $ kcreg.sh update myclient -s enabled=false -d redirectUris
 ----
-
-On Windows:
-[source,bash]
+* Windows:
+[options="nowrap"]
 ----
 C:\> kcreg update myclient -s enabled=false -d redirectUris
 ----
 
+You can also use a file that contains only changes to be applied so you do not have to specify too many values as arguments. In this case, specify [command]`--merge` to tell the Client Registration CLI that rather than treating the JSON file as a full, new configuration, it should treat it as a set of attributes to be applied over the existing configuration.
 
-You can even use a file that only contains changes to be applied so you don't have to specify too many values as arguments.
-In this case specify `--merge` to tell `Client Registration CLI` that rather than treating JSON file as full
-new configuration, it should treat it as a set of attributes to be applied over existing configuration.
+For example, on: 
 
-
-On Linux:
-[source,bash]
+* Linux:
+[options="nowrap"]
 ----
 $ kcreg.sh update myclient --merge -d redirectUris -f mychanges.json
 ----
-
-On Windows:
-[source,bash]
+* Windows:
+[options="nowrap"]
 ----
 C:\> kcreg update myclient --merge -d redirectUris -f mychanges.json
 ----
 
-See `kcreg update --help` for more information about `kcreg update`.
+Run the [command]`kcreg update --help` command for more information about the [command]`kcreg update` command.
 
-==== Deleting client configuration
 
-You may sometimes also need to delete a client.
+==== Deleting a client configuration
 
-On Linux:
-[source,bash]
+Use the following example to delete a client.
+
+* Linux:
+[options="nowrap"]
 ----
 $ kcreg.sh delete myclient
 ----
-
-On Windows:
-[source,bash]
+*  Windows:
+[options="nowrap"]
 ----
 C:\> kcreg delete myclient
 ----
 
-See `kcreg delete --help` for more information about `kcreg delete`.
-
+Run the [command]`kcreg delete --help` command for more information about the [command]`kcreg delete` command.
 
 
 [[_refreshing_invalid_registration_access_tokens]]
-==== Refreshing Invalid Registration Access Tokens
+==== Refreshing invalid Registration Access Tokens
 
-When performing a CRUD operation using `--no-config` mode, `Client Registration CLI` can no longer handle Registration Access Tokens for you.
-In that case it is possible to lose track of most recently issued Registration Access Token for a client, which makes it impossible to
-perform any further CRUD operations on that client without authenticating with account that has 'manage-clients' permissions.
+When performing a create, read, update, and delete (CRUD) operation using the [command]`--no-config` mode, the Client Registration CLI cannot handle Registration Access Tokens for you. In that case, it is possible to lose track of the most recently issued Registration Access Token for a client, which makes it impossible to perform any further CRUD operations on that client without authenticating with an account that has *manage-clients* permissions.
 
-If you have permissions, you can issue a new Registration Access Token for the client, and have it printed to stdout or saved to a config
-file of your choice. Otherwise you have to ask realm administrator to issue new Registration Access Token for your client, and send it
-to you. You can then pass it to any CRUD command via `--token` option. You can also use `kcreg config registration-token`
-command to save the new token in configuration file, and have `Client Registration CLI` automatically handle it for you from that point on.
+If you have permissions, you can issue a new Registration Access Token for the client and have it printed to a standard output or saved to a configuration file of your choice. Otherwise, you have to ask the realm administrator to issue new a Registration Access Token for your client and send it to you. You can then pass it to any CRUD command via the [command]`--token` option. You can also use the [command]`kcreg config registration-token` command to save the new token in a configuration file and have the Client Registration CLI automatically handle it for you from that point on.
 
-See `kcreg update-token --help` for more information about `kcreg update-token`.
-
+Run the [command]`kcreg update-token --help` command for more information about the [command]`kcreg update-token` command.
 
 
 [[_troubleshooting_2]]
 === Troubleshooting
 
-* Q: When logging in I get an error: `Parameter client_assertion_type is missing [invalid_client]`
+* Q: When logging in, I get an error: *Parameter client_assertion_type is missing [invalid_client].
 +
-A: Your client is configured with `Signed JWT` token credentials which means you have to use `--keystore` parameter when logging in.
+A: This error means your client is configured with [filename]`Signed JWT` token credentials, which means you have to use the [command]`--keystore` parameter when logging in.

--- a/securing_apps/topics/client-registration/client-registration-cli.adoc
+++ b/securing_apps/topics/client-registration/client-registration-cli.adoc
@@ -7,7 +7,7 @@ It is necessary to create or obtain a client configuration for any application t
 
 You can configure application clients from a command line with the Client Registration CLI, and you can use it in shell scripts.
 
-The {project_name} administrator typically uses the Admin Console to allow a particular user to use the Client Registration CLI to configure a new user with proper roles or configure a new client and a client secret to grant access to the Client Registration REST API.
+To allow a particular user to use `Client Registration CLI` the {project_name} administrator typically uses the Admin Console to configure a new user with proper roles or to configure a new client and client secret to grant access to the Client Registration REST API.
 
 
 [[_configuring_a_user_for_client_registration_cli]]
@@ -17,7 +17,7 @@ The {project_name} administrator typically uses the Admin Console to allow a par
 . Select a realm to administer.
 . If you want to use an existing user, select that user to edit; otherwise, create a new user.
 . Select *Role Mappings > Client Roles > realm-management*. If you are in the master realm, select *NAME-realm*, where `NAME` is the name of the target realm. You can grant access to any other realm to users in the master realm.
-. Select *Available Roles > manage-client* to display a full set of client management permissions. Another option is to choose *view-clients* for read-only or *create-client* to create new clients.
+. Select *Available Roles > manage-client* to grant a full set of client management permissions. Another option is to choose *view-clients* for read-only or *create-client* to create new clients.
 +
 [NOTE]
 ====
@@ -32,7 +32,7 @@ The Administrator can issue Initial Access Tokens from the Admin Console through
 [[_configuring_a_client_for_use_with_client_registration_cli]]
 === Configuring a client for use with the Client Registration CLI
 
-By default, the server recongizes the Client Registration CLI as the [filename]`admin-cli` client, which is configured automatically for every new realm. No additional client configuration is necessary when logging in with a user name.
+By default, the server recognizes the Client Registration CLI as the [filename]`admin-cli` client, which is configured automatically for every new realm. No additional client configuration is necessary when logging in with a user name.
 
 . Strengthen the security by configuring the client [filename]`Access Type` as [filename]`Confidential` and selecting *Credentials > ClientId and Secret*.
 . Provide a secret when running [command]`kcreg config credentials` by using the [command]`--secret` option.
@@ -45,7 +45,7 @@ By default, the server recongizes the Client Registration CLI as the [filename]`
 ====
 You can configure either [filename]`Client Id and Secret` or [filename]`Signed JWT` under the *Credentials* tab .
 ====
-. You can omit specifying the user when running [command]`kcreg config credentials` and only provide the client secret or keystore information.
+. With the service account enabled, you can omit specifying the user when running [command]`kcreg config credentials` and only provide the client secret or keystore information.
 
 
 [[_installing_client_registration_cli]]
@@ -124,7 +124,7 @@ c:\> kcreg config truststore --trustpass %PASSWORD% %HOMEPATH%\.keycloak\trustst
 ==== Logging in
 
 . Specify a server endpoint URL and a realm when you log in with the Client Registration CLI.
-. Specify a user name or a client ID, which results in a special service account being used. When using a user name, you must use a password for the specified user. When using a client ID, you use a client secret or a [filename]`Signed JWT` instead of a password.
+. Specify a user name or a client id, which results in a special service account being used. When using a user name, you must use a password for the specified user. When using a client ID, you use a client secret or a [filename]`Signed JWT` instead of a password.
 
 Regardless of the login method, the account that logs in needs proper permissions to be able to perform client registration operations. Keep in mind that any account in a non-master realm can only have permissions to manage clients within the same realm. If you need to manage different realms, you can either configure multiple users in different realms, or you can create a single user in the [filename]`master` realm and add roles for managing clients in different realms.
 
@@ -166,7 +166,7 @@ You might want to avoid storing secrets inside a configuration file by using the
 [[_initial_access_and_registration_access_tokens]]
 ==== Initial Access and Registration Access Tokens
 
-Developers who do not have an account configured at the Keycloak server they want to use can use the Client Registration CLI. That is possible when the realm administrator issues a developer an Initial Access Token. It is up to the realm administrator to decide how to issue and distribute these tokens. The realm administrator can limit the maximum age of the Initial Access Token and the total number of clients that can be created with it. Many Initial Access Tokens can be created; it is up to realm administrator to distribute them to application developers.
+Developers who do not have an account configured at the Keycloak server they want to use can use the Client Registration CLI. That is possible when the realm administrator issues a developer an Initial Access Token. It is up to the realm administrator to decide how to issue and distribute these tokens. The realm administrator can limit the maximum age of the Initial Access Token and the total number of clients that can be created with it.
 
 Once a developer has an Initial Access Token, the developer can use it to create new clients without authenticating with [command]`kcreg config credentials`. The Initial Access Token can be stored in the configuration file or specified as part of the [command]`kcreg create` command.
 
@@ -214,7 +214,7 @@ Run the [command]`kcreg config initial-token --help` and [command]`kcreg config 
 
 The first task after authenticating with credentials or configuring an Initial Access Token is usually to create a new client. Often you might want to use a prepared JSON file as a template and set or override some of the attributes.
 
-The following example shows how to read a JSON file, override any client ID it may contain, set any other attributes, and print the configuration to a standard output after successful creation.
+The following example shows how to read a JSON file, override any client id it may contain, set any other attributes, and print the configuration to a standard output after successful creation.
 
 * Linux:
 [options="nowrap"]
@@ -229,7 +229,7 @@ C:\> kcreg create -f client-template.json -s clientId=myclient -s baseUrl=/mycli
 
 Run the [command]`kcreg create --help` for more information about the [command]`kcreg create` command.
 
-You can use [command]`kcreg attrs` to list available attributes. Keep in mind that many configuration attributes are not checked for validity or consistency. It is up to you to specify proper values. Remember that you should not have any ID fields in your
+You can use [command]`kcreg attrs` to list available attributes. Keep in mind that many configuration attributes are not checked for validity or consistency. It is up to you to specify proper values. Remember that you should not have any id fields in your
 template and should not specify them as arguments to the [command]`kcreg create` command.
 
 
@@ -250,7 +250,7 @@ $ kcreg.sh get myclient
 C:\> kcreg get myclient
 ----
 
-You can also see the client configuration as an adapter configuration file, which you can package with your web application.
+You can also retrieve the client configuration as an adapter configuration file, which you can package with your web application.
 
 For example, on:
 
@@ -272,7 +272,7 @@ Run the [command]`kcreg get --help` command for more information about the [comm
 
 There are two methods for updating a client configuration.
 
-One method submits a complete new state to the server after getting the current configuration, saving it to a file, editing it, and posting it back to the server.
+One method is to submit a complete new state to the server after getting the current configuration, saving it to a file, editing it, and posting it back to the server.
 
 For example, on:
 
@@ -291,7 +291,7 @@ C:\> notepad myclient.json
 C:\> kcreg update myclient -f myclient.json
 ----
 
-The second methods fetches the current client, sets or deletes fields on it, and posts it back in one step.
+The second method fetches the current client, sets or deletes fields on it, and posts it back in one step.
 
 For example, on:
 
@@ -347,7 +347,7 @@ Run the [command]`kcreg delete --help` command for more information about the [c
 
 When performing a create, read, update, and delete (CRUD) operation using the [command]`--no-config` mode, the Client Registration CLI cannot handle Registration Access Tokens for you. In that case, it is possible to lose track of the most recently issued Registration Access Token for a client, which makes it impossible to perform any further CRUD operations on that client without authenticating with an account that has *manage-clients* permissions.
 
-If you have permissions, you can issue a new Registration Access Token for the client and have it printed to a standard output or saved to a configuration file of your choice. Otherwise, you have to ask the realm administrator to issue new a Registration Access Token for your client and send it to you. You can then pass it to any CRUD command via the [command]`--token` option. You can also use the [command]`kcreg config registration-token` command to save the new token in a configuration file and have the Client Registration CLI automatically handle it for you from that point on.
+If you have permissions, you can issue a new Registration Access Token for the client and have it printed to a standard output or saved to a configuration file of your choice. Otherwise, you have to ask the realm administrator to issue a new Registration Access Token for your client and send it to you. You can then pass it to any CRUD command via the [command]`--token` option. You can also use the [command]`kcreg config registration-token` command to save the new token in a configuration file and have the Client Registration CLI automatically handle it for you from that point on.
 
 Run the [command]`kcreg update-token --help` command for more information about the [command]`kcreg update-token` command.
 


### PR DESCRIPTION
This topic is Chapter 6, Client Registration CLI for the Keycloak documentation.

Edits include:
* Revising AsciiDoc syntax
* Adding numbered steps, where applicable
* Adding articles and nouns to reduce ambiguity
* Following IBM Style Guide conventions
* Changing future tense to present tense
* Changing mood to imperative mood