### PR TITLE
Remove spurious extra heading, and menu item, from PayPal section

### DIFF
--- a/server_admin/topics/identity-broker/social/paypal.adoc
+++ b/server_admin/topics/identity-broker/social/paypal.adoc
@@ -22,9 +22,7 @@ Click the `Create App` button.
 .Register App
 image:images/paypal-register-app.png[]
 
-You will now be brought to the app settings page.
-
-==== Do the following changes:
+You will now be brought to the app settings page. Complete the following steps:
 
 - Choose to configure either Sandbox or Live (choose Live if you haven't enabled the `Target Sandbox` switch on the `Add identity provider` page)
 - Copy Client ID and Secret so you can paste them into the {project_name} `Add identity provider` page.


### PR DESCRIPTION
The documentation contains a section "12.4.8. Do the following changes:" which should really just be part of the PayPal section (12.4.7).