### PR TITLE
KEYCLOAK-6102 fixes from QE review

### DIFF
--- a/securing_apps/topics/client-registration/client-registration-cli.adoc
+++ b/securing_apps/topics/client-registration/client-registration-cli.adoc
@@ -166,7 +166,7 @@ You might want to avoid storing secrets inside a configuration file by using the
 [[_initial_access_and_registration_access_tokens]]
 ==== Initial Access and Registration Access Tokens
 
-Developers who do not have an account configured at the {project_name} server they want to use can instead use the Client Registration CLI. This is possible only when the realm administrator issues a developer an Initial Access Token. It is up to the realm administrator to decide how and when to issue and distribute these tokens. The realm administrator can limit the maximum age of the Initial Access Token and the total number of clients that can be created with it.
+Developers who do not have an account configured at the {project_name} server they want to use can use the Client Registration CLI. This is possible only when the realm administrator issues a developer an Initial Access Token. It is up to the realm administrator to decide how and when to issue and distribute these tokens. The realm administrator can limit the maximum age of the Initial Access Token and the total number of clients that can be created with it.
 
 Once a developer has an Initial Access Token, the developer can use it to create new clients without authenticating with [command]`kcreg config credentials`. The Initial Access Token can be stored in the configuration file or specified as part of the [command]`kcreg create` command.
 

--- a/securing_apps/topics/client-registration/client-registration-cli.adoc
+++ b/securing_apps/topics/client-registration/client-registration-cli.adoc
@@ -39,7 +39,7 @@ By default, the server recognizes the Client Registration CLI as the [filename]`
 . Create a new client (for example, [filename]`reg-cli`) if you want to use a separate client configuration for the Client Registration CLI.
 . Specify which [filename]`clientId` to use (for example, [command]`--client reg-cli`) when running [command]`kcreg config credentials`.
 . Enable service accounts if you want to use a service account associated with the client by selecting a client to edit in the *Clients* section of the `Admin Console`.
-. Under *Settings*, change the *Access Type* to *Confidential*, toggle the *Service Accounts Enabled* setting to *On*, and click [btn]`Save`.
+. Under *Settings*, change the *Access Type* to *Confidential*, toggle the *Service Accounts Enabled* setting to *On*, and click *Save*.
 +
 [NOTE]
 ====
@@ -51,9 +51,9 @@ You can configure either [filename]`Client Id and Secret` or [filename]`Signed J
 [[_installing_client_registration_cli]]
 === Installing the Client Registration CLI
 
-The Client Registration CLI is packaged inside the Keycloak Server distribution. You can find execution scripts inside the [filename]`bin` directory. The Linux script is called [filename]`kcreg.sh`, and the Windows script is called [filename]`kcreg.bat`.
+The Client Registration CLI is packaged inside the {project_name} Server distribution. You can find execution scripts inside the [filename]`bin` directory. The Linux script is called [filename]`kcreg.sh`, and the Windows script is called [filename]`kcreg.bat`.
 
-Add the Keycloak server directory to your [filename]`PATH` when setting up the client for use from any location on the file system.
+Add the {project_name} server directory to your [filename]`PATH` when setting up the client for use from any location on the file system.
 
 For example, on:
 
@@ -70,7 +70,7 @@ c:\> set PATH=%PATH%;%KEYCLOAK_HOME%\bin
 c:\> kcreg
 ----
 
-[filename]`KEYCLOAK_HOME` refers to a directory where the Keycloak Server distribution was unpacked.
+[filename]`KEYCLOAK_HOME` refers to a directory where the {project_name} Server distribution was unpacked.
 
 
 [[_using_client_registration_cli]]
@@ -100,7 +100,7 @@ c:\> kcreg get my_client
 +
 [NOTE]
 ====
-In a production environment, Keycloak has to be accessed with [filename]`https:` to avoid exposing tokens to network sniffers.
+In a production environment, {project_name} has to be accessed with [filename]`https:` to avoid exposing tokens to network sniffers.
 ====
 . If a server's certificate is not issued by one of the trusted certificate authorities (CAs) that are included in Java's default certificate truststore, prepare a [filename]`truststore.jks` file and instruct the Client Registration CLI to use it.
 +
@@ -166,7 +166,7 @@ You might want to avoid storing secrets inside a configuration file by using the
 [[_initial_access_and_registration_access_tokens]]
 ==== Initial Access and Registration Access Tokens
 
-Developers who do not have an account configured at the Keycloak server they want to use can use the Client Registration CLI. That is possible when the realm administrator issues a developer an Initial Access Token. It is up to the realm administrator to decide how to issue and distribute these tokens. The realm administrator can limit the maximum age of the Initial Access Token and the total number of clients that can be created with it.
+Developers who do not have an account configured at the {project_name} server they want to use can instead use the Client Registration CLI. This is possible only when the realm administrator issues a developer an Initial Access Token. It is up to the realm administrator to decide how and when to issue and distribute these tokens. The realm administrator can limit the maximum age of the Initial Access Token and the total number of clients that can be created with it.
 
 Once a developer has an Initial Access Token, the developer can use it to create new clients without authenticating with [command]`kcreg config credentials`. The Initial Access Token can be stored in the configuration file or specified as part of the [command]`kcreg create` command.
 

--- a/securing_apps/topics/oidc/java/jboss-adapter.adoc
+++ b/securing_apps/topics/oidc/java/jboss-adapter.adoc
@@ -193,36 +193,31 @@ endif::[]
 
 This ZIP archive contains JBoss Modules specific to the {project_name} adapter. It also contains JBoss CLI scripts to configure the adapter subsystem.
 
-To configure the adapter subsystem if the server is not running execute:
+If the server is not running, to configure the adapter subsystem execute:
 
-ifeval::[{project_community}==true]
-.Wildfly 11
+.Elytron adapter, available on Wildfly 11 or EAP 7.1 only
 [source]
 ----
 $ ./bin/jboss-cli.sh --file=adapter-elytron-install-offline.cli
 ----
 
-.Any other server but Wildfly 11
-endif::[]
-
+.Legacy adapter, available on WildFly 11 or EAP 7.1 or older
 [source]
 ----
 $ ./bin/jboss-cli.sh --file=adapter-install-offline.cli
 ----
 
-NOTE: The offline script is not available for JBoss EAP 6
+NOTE: The offline script is not available for JBoss EAP 6. On this platform you will use `adapter-install.cli`.
 
 Alternatively, if the server is running execute:
 
-ifeval::[{project_community}==true]
-.Wildfly 11
+.Elytron adapter, available on Wildfly 11 or EAP 7.1 only
 [source]
 ----
 $ ./bin/jboss-cli.sh --file=adapter-elytron-install.cli
 ----
 
-.Any other server but Wildfly 11
-endif::[]
+.Legacy adapter, available on WildFly 11 or EAP 7.1 or older
 
 [source]
 ----

--- a/securing_apps/topics/oidc/java/jboss-adapter.adoc
+++ b/securing_apps/topics/oidc/java/jboss-adapter.adoc
@@ -201,9 +201,10 @@ ifeval::[{project_community}==true]
 ----
 $ ./bin/jboss-cli.sh --file=adapter-elytron-install-offline.cli
 ----
-endif::[]
 
 .Any other server but Wildfly 11
+endif::[]
+
 [source]
 ----
 $ ./bin/jboss-cli.sh --file=adapter-install-offline.cli
@@ -219,9 +220,10 @@ ifeval::[{project_community}==true]
 ----
 $ ./bin/jboss-cli.sh --file=adapter-elytron-install.cli
 ----
-endif::[]
 
 .Any other server but Wildfly 11
+endif::[]
+
 [source]
 ----
 $ ./bin/jboss-cli.sh --file=adapter-install.cli

--- a/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc
+++ b/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc
@@ -58,9 +58,10 @@ ifeval::[{project_community}==true]
 ----
 $ ./bin/jboss-cli.sh --file=adapter-elytron-install-saml.cli
 ----
-endif::[]
 
 .Any other server but Wildfly 11
+endif::[]
+
 [source]
 ----
 
@@ -71,7 +72,7 @@ The script will add the extension, subsystem, and optional security-domain as de
 
 [source,xml]
 ----
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:5.0">
 
     <extensions>
         <extension module="org.keycloak.keycloak-saml-adapter-subsystem"/>
@@ -91,8 +92,8 @@ Otherwise this configuration is optional.
 [source,xml]
 ----
 
-<server xmlns="urn:jboss:domain:1.4">
- <subsystem xmlns="urn:jboss:domain:security:1.2">
+<server xmlns="urn:jboss:domain:5.0">
+ <subsystem xmlns="urn:jboss:domain:security:2.0">
     <security-domains>
 ...
       <security-domain name="keycloak">

--- a/topics/templates/document-attributes-community.adoc
+++ b/topics/templates/document-attributes-community.adoc
@@ -44,7 +44,7 @@
 :installguide_loadbalancer_name: Setting Up a Load Balancer or Proxy
 :installguide_loadbalancer_link: {installguide_link}#_setting-up-a-load-balancer-or-proxy
 :installguide_profile_name: Profiles
-:installguide_profile_link: {installguide_link}#_profiles
+:installguide_profile_link: {installguide_link}#profiles
 :installguide_stickysessions_name: Sticky sessions
 :installguide_stickysessions_link: {installguide_link}#sticky-sessions
 :installguide_troubleshooting_name: Troubleshooting

--- a/topics/templates/document-attributes-product.adoc
+++ b/topics/templates/document-attributes-product.adoc
@@ -2,8 +2,8 @@
 :project_community: false
 :project_product: true
 :project_version: 7.2.0.GA
-:project_versionMvn: 3.4.2.Final-redhat1
-:project_versionNpm: 3.4.2.Final-redhat1
+:project_versionMvn: 3.4.2.Final-redhat-2
+:project_versionNpm: 3.4.2.Final-redhat-2
 :project_versionDoc: 7.2
 :project_images: rhsso-images
 :project_doc_base_url: https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{project_versionDoc}/html-single
@@ -44,7 +44,7 @@
 :installguide_loadbalancer_name: Setting Up a Load Balancer or Proxy
 :installguide_loadbalancer_link: {installguide_link}#_setting-up-a-load-balancer-or-proxy
 :installguide_profile_name: Profiles
-:installguide_profile_link: {installguide_link}#_profiles
+:installguide_profile_link: {installguide_link}#profiles
 :installguide_stickysessions_name: Sticky sessions
 :installguide_stickysessions_link: {installguide_link}#sticky-sessions
 :installguide_troubleshooting_name: Troubleshooting

--- a/topics/templates/document-attributes-product.adoc
+++ b/topics/templates/document-attributes-product.adoc
@@ -2,8 +2,8 @@
 :project_community: false
 :project_product: true
 :project_version: 7.2.0.GA
-:project_versionMvn: 3.4.2.Final-redhat-2
-:project_versionNpm: 3.4.2.Final-redhat-2
+:project_versionMvn: 3.4.3.Final-redhat-2
+:project_versionNpm: 3.4.3.Final-redhat-2
 :project_versionDoc: 7.2
 :project_images: rhsso-images
 :project_doc_base_url: https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{project_versionDoc}/html-single


### PR DESCRIPTION
Here are the comments from the report, with my responses. @stianst will you please select a knowledgeable person to help me answer the parts I don't have the knowledge to answer?

> I've done the Client Registration CLI review and I've found several issues.
> [RH-SSO only] Many places throughout the whole Chapter 6. of Securing Applications and Services Guide
> Keycloak instead of RH-SSO is mentioned everywhere

I have changed this to `{project_name}` in text, but not in code. I need someone who knows the code to help me understand where/if this should be changed in code examples.

> Chapter 6.2. Configuring a client for use with the Client Registration CLI
> [RH-SSO only] In the step 6, instead of the word “Save” there’s some weird and unexpected SAVE button.

Fixed.

> The  whole chapter is a bit erratic and incomplete. Doesn’t e.g. mention that Standard Flow should be disabled (so no valid redirect URLs would be required) or that Direct Access Grants needs to be enabled to login as a user when not using service accounts. Service account roles are not mentioned either.

I need further guidance and information on the technical aspects in order to write up the missing information.

> 6.4.3. Initial Access and Registration Access Tokens
> The first sentence of the first paragraph doesn’t make sense.

I have edited the entire paragraph.