### PR TITLE
KEYCLOAK-5852 error in securing apps example

### DIFF
--- a/securing_apps/topics/token-exchange/token-exchange.adoc
+++ b/securing_apps/topics/token-exchange/token-exchange.adoc
@@ -255,7 +255,7 @@ curl -X POST \
     -d "client_secret=geheim" \
     --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
     -d "subject_token=...." \
-    --data-urlencode "requested_token_type=urn:ietf:params:oauth:token-type:refresh_token"
+    --data-urlencode "requested_token_type=urn:ietf:params:oauth:token-type:access_token"
     -d "requested_issuer=google" \
     http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token
 ----


### PR DESCRIPTION
It seems to me that there are two possibilities here: that the curl example is incorrect OR that the statement after it is incorrect. I edited the curl example, but would appreciate a knowledgable engineer to confirm it was what needed to be changed before we merge.