### PR TITLE
Added link to Jira in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@ Keycloak Documentation
 
 Open Source Identity and Access Management for modern Applications and Services.
 
-For more information about Keycloak visit [Keycloak homepage](http://keycloak.org) and [Keycloak blog](http://blog.keycloak.org).
+For more information about Keycloak visit the [Keycloak homepage](http://keycloak.org) and [Keycloak blog](http://blog.keycloak.org).
 
 
 Contributing to Keycloak Documentation
 --------------------------------------
 
 See our [Contributor's Guide](internal_resources/contributing.adoc). The directory also includes a set of templates and other resources to help you get started.
+
+If you want to file a bug report or tell us about any other issue with this documentation, you are invited to please use our [issue tracker](https://issues.jboss.org/projects/KEYCLOAK/).
 
 
 Building Keycloak Documentation


### PR DESCRIPTION
This just seems like really useful information to put here, for the convenience of users.

I also added a missing "the".