### PR TITLE
Update spring-security-adapter configuration of filters

### DIFF
--- a/securing_apps/topics/oidc/java/spring-security-adapter.adoc
+++ b/securing_apps/topics/oidc/java/spring-security-adapter.adoc
@@ -261,7 +261,7 @@ public KeycloakConfigResolver KeycloakConfigResolver() {
 ====== Avoid double Filter bean registration
 
 Spring Boot attempts to eagerly register filter beans with the web application context.
-Therefore, when running the Keycloak Spring Security adapter in a Spring Boot environment, it may be necessary to add two ``FilterRegistrationBean``s to your security configuration to prevent the Keycloak filters from being registered twice.
+Therefore, when running the Keycloak Spring Security adapter in a Spring Boot environment, it may be necessary to add ``FilterRegistrationBean``s to your security configuration to prevent the Keycloak filters from being registered twice.
 
 
 [source,java]
@@ -285,6 +285,22 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter
     @Bean
     public FilterRegistrationBean keycloakPreAuthActionsFilterRegistrationBean(
             KeycloakPreAuthActionsFilter filter) {
+        FilterRegistrationBean registrationBean = new FilterRegistrationBean(filter);
+        registrationBean.setEnabled(false);
+        return registrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean keycloakAuthenticatedActionsFilterBean(
+            KeycloakAuthenticatedActionsFilter filter) {
+        FilterRegistrationBean registrationBean = new FilterRegistrationBean(filter);
+        registrationBean.setEnabled(false);
+        return registrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean keycloakSecurityContextRequestFilterBean(
+        KeycloakSecurityContextRequestFilter filter) {
         FilterRegistrationBean registrationBean = new FilterRegistrationBean(filter);
         registrationBean.setEnabled(false);
         return registrationBean;


### PR DESCRIPTION
Two new Keycloak filters were introduced since last update of the documentation:
- https://github.com/keycloak/keycloak/commit/04ad6349863d26204adf9a87ad7626378204add8
- https://github.com/keycloak/keycloak/commit/819a60932e94832cd888acd1ee904b730ab3bdc3

 I'm adding them to documentation to the example of disabling double registration by Spring.