### PR TITLE
Document Javascript adapter's scope support

### DIFF
--- a/securing_apps/topics/oidc/javascript-adapter.adoc
+++ b/securing_apps/topics/oidc/javascript-adapter.adoc
@@ -263,6 +263,7 @@ Options is an Object, where:
 * loginHint - Used to pre-fill the username/email field on the login form.
 * action - If value is 'register' then user is redirected to registration page, otherwise to login page.
 * locale - Specifies the desired locale for the UI.
+* scope - A string containing OAuth scopes to request, separated by space. Each http://www.keycloak.org/docs/latest/server_admin/index.html#realm-roles[realm role] maps to a scope using its role name. Each http://www.keycloak.org/docs/latest/server_admin/index.html#client-roles[client role] maps to a scope by `client-name/role-name`.
 
 ====== createLoginUrl(options)
 


### PR DESCRIPTION
People are asking about Javascript adapter's scope on [StackOverflow](https://stackoverflow.com/questions/35270343/keycloak-javascript-adapter-request-offline-token). This should be documented.

Related:
- http://lists.jboss.org/pipermail/keycloak-user/2016-August/007407.html
- https://stackoverflow.com/questions/35270343/keycloak-javascript-adapter-request-offline-token