### PR TITLE
[KEYCLOAK-6857] Deprecate RH-SSO 7.1 image

### DIFF
--- a/openshift/content/before_you_begin/before_you_begin.adoc
+++ b/openshift/content/before_you_begin/before_you_begin.adoc
@@ -10,9 +10,9 @@ See the xPaaS part of the https://access.redhat.com/articles/2176281[OpenShift a
 
 [IMPORTANT]
 ====
-The {xpaasproduct-shortname} image version number 7.0 is deprecated and it will no longer receive updates of image and application templates.
+The {xpaasproduct-shortname} image version number 7.0 and 7.1 are deprecated and they will no longer receive updates of image and application templates.
 
-*To deploy new applications, it is recommended to use the version 7.1 or 7.2 of the {xpaasproduct-shortname} image along with the application templates specific to those versions.*
+*To deploy new applications, it is recommended to use the version 7.2 of the {xpaasproduct-shortname} image along with the application templates specific to that version.*
 ====
 
 === Initial Setup

--- a/openshift/content/get_started/get_started.adoc
+++ b/openshift/content/get_started/get_started.adoc
@@ -111,9 +111,9 @@ When deploying RH-SSO application template, *_SSO_ADMIN_USERNAME_* and *_SSO_ADM
 ====
 The lifespan of the RH-SSO server's administrator account depends upon the the storage type used to store the RH-SSO server's database:
 
-* For an in-memory database mode (*_sso71-https_* and *_sso72-https_* templates) the account exist throughout the lifecycle of the particular RH-SSO pod (stored account data is lost upon pod destruction),
-* For an ephemeral database mode (*_sso71-mysql_*, *_sso71-postgresql_*, *_sso72-mysql_*, and *_sso72-postgresql_* templates) the account exist throughout the lifecycle of the database pod (even if RH-SSO pod is destructed, the stored account data is preserved under the assumption that the database pod is still running),
-* For persistent database mode (*_sso71-mysql-persistent_*, *_sso71-postgresql-persistent_*, *_sso72-mysql-persistent_*, and *_sso72-postgresql-persistent_* templates) the account exists throughout the lifecycle of the persistent medium used to hold the database data. This means that the stored account data is preserved even when both, the RH-SSO and the database pods are destructed.
+* For an in-memory database mode (*_sso72-https_* template) the account exist throughout the lifecycle of the particular RH-SSO pod (stored account data is lost upon pod destruction),
+* For an ephemeral database mode (*_sso72-mysql_* and *_sso72-postgresql_* templates) the account exist throughout the lifecycle of the database pod (even if RH-SSO pod is destructed, the stored account data is preserved under the assumption that the database pod is still running),
+* For persistent database mode (*_sso72-mysql-persistent_* and *_sso72-postgresql-persistent_* templates) the account exists throughout the lifecycle of the persistent medium used to hold the database data. This means that the stored account data is preserved even when both, the RH-SSO and the database pods are destructed.
 
 It is a common practice to deploy an RH-SSO application template to get the corresponding OpenShift deployment config for the application, and then reuse that deployment config multiple times (every time a new RH-SSO application needs to be instantiated).
 ====
@@ -256,7 +256,7 @@ For more information on OpenShift route types, see the link:https://docs.openshi
 
 ==== Deployment Process
 
-Once deployed, the *_sso71-https_* and *_sso72-https_* templates create a single pod that contains both the database and the RH-SSO servers. The *_sso71-mysql_*, *_sso72-mysql_*, *_sso71-mysql-persistent_*, *_sso72-mysql-persistent_*, *_sso71-postgresql_*, *_sso72-postgresql_*, *_sso71-postgresql-persistent_*, and *_sso72-postgresql-persistent_* templates create two pods, one for the database server and one for the RH-SSO web server.
+Once deployed, the *_sso72-https_* template creates a single pod that contains both the database and the RH-SSO servers. The *_sso72-mysql_*, *_sso72-mysql-persistent_*, *_sso72-postgresql_*, and *_sso72-postgresql-persistent_* templates create two pods, one for the database server and one for the RH-SSO web server.
 
 After the RH-SSO web server pod has started, it can be accessed at its custom configured hostnames, or at the default hostnames:
 
@@ -397,13 +397,9 @@ The following example uses both link:https://github.com/keycloak/keycloak-quicks
 ====
 This guide assumes the {xpaasproduct-shortname} image has been previously link:https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html-single/red_hat_jboss_sso_for_openshift/#Example-Deploying-SSO[deployed using one of the following templates:]
 
-* *_sso71-mysql_*
 * *_sso72-mysql_*
-* *_sso71-postgresql_*
 * *_sso72-postgresql_*
-* *_sso71-mysql-persistent_*
 * *_sso72-mysql-persistent_*
-* *_sso71-postgresql-persistent_*
 * *_sso72-postgresql-persistent_*
 ====
 
@@ -428,12 +424,13 @@ In the newly created `demo` realm, click the *Keys* tab and copy the public key 
 
 [NOTE]
 ====
-RH-SSO 7.1 and RH-SSO 7.2 images generate two keys by default:
+The RH-SSO 7.2 image generates three keys by default:
 
-* RSA key, and
-* HMAC key
+* RSA key,
+* HMAC key, and
+* AES key
 
-To copy the public key information for the RH-SSO 7.1 or RH-SSO 7.2 image, click the *Public key* button of the *RSA* row of the keys table. Then select and copy the content of the pop-up window that appears.
+To copy the public key information for the RH-SSO 7.2 image, click the *Public key* button of the *RSA* row of the keys table. Then select and copy the content of the pop-up window that appears.
 ====
 
 The information about the public key is necessary xref:sso-public-key-details[later to deploy] the RH-SSO-enabled EAP 6.4 / 7.0 JSP application.
@@ -457,7 +454,7 @@ Create `user` and `admin` roles in RH-SSO. These roles will be assigned to an RH
 ====
 This is a new realm, so there should only be the default roles:
 
-* `offline_access` and `uma_authorization` role for the RH-SSO 7.1 and RH-SSO 7.2 images.
+* `offline_access` and `uma_authorization` role for the RH-SSO 7.2 image.
 ====
 . Click *Add Role*.
 . Enter the role name (`user`) and click *Save*.

--- a/openshift/content/introduction/introduction.adoc
+++ b/openshift/content/introduction/introduction.adoc
@@ -12,14 +12,6 @@ For RH-SSO 7.2:
 * *_sso72-postgresql_*: RH-SSO 7.2 backed by ephemeral PostgreSQL database on a separate pod.
 * *_sso72-postgresql-persistent_*: RH-SSO 7.2 backed by persistent PostgreSQL database on a separate pod.
 
-For RH-SSO 7.1:
-
-* *_sso71-https_*: RH-SSO 7.1 backed by internal H2 database on the same pod.
-* *_sso71-mysql_*: RH-SSO 7.1 backed by ephemeral MySQL database on a separate pod.
-* *_sso71-mysql-persistent_*: RH-SSO 7.1 backed by persistent MySQL database on a separate pod.
-* *_sso71-postgresql_*: RH-SSO 7.1 backed by ephemeral PostgreSQL database on a separate pod.
-* *_sso71-postgresql-persistent_*: RH-SSO 7.1 backed by persistent PostgreSQL database on a separate pod.
-
 Other templates that integrate with RH-SSO are also available:
 
 * *_eap64-sso-s2i_*: RH-SSO-enabled Red Hat JBoss Enterprise Application Platform 6.4.

--- a/openshift/content/reference/reference.adoc
+++ b/openshift/content/reference/reference.adoc
@@ -33,7 +33,7 @@ information about the image and should not be modified by the user:
 
 |*_JBOSS_IMAGE_NAME_*
 |Image name, same as Name label.
-|*_redhat-sso-7/sso71-openshift_* or *_redhat-sso-7/sso72-openshift_*
+|*_redhat-sso-7/sso72-openshift_*
 
 |*_JBOSS_IMAGE_RELEASE_*
 |Image release, same as Release label.
@@ -362,7 +362,7 @@ if this environment variable is provided.
 |The password for the truststore and certificate.
 |===
 
-==== Template variables specific to *sso71-mysql*, *sso72-mysql*, *sso71-mysql-persistent*, and *sso72-mysql-persistent*
+==== Template variables specific to *sso72-mysql* and *sso72-mysql-persistent*
 
 .Configuration Variables Specific To RH-SSO-enabled MySQL Applications With Ephemeral Or Persistent Storage
 [cols="2*", options="header"]
@@ -396,7 +396,7 @@ broken.
 |The maximum permitted number of simultaneous client connections.
 |===
 
-==== Template variables specific to *sso71-postgresql*, *sso72-postgresql*, *sso71-postgresql-persistent*, and *sso72-postgresql-persistent*
+==== Template variables specific to *sso72-postgresql* and *sso72-postgresql-persistent*
 
 .Configuration Variables Specific To RH-SSO-enabled PostgreSQL Applications With Ephemeral Or Persistent Storage
 [cols="2*", options="header"]
@@ -421,7 +421,7 @@ number of prepared transactions.
 |Configures how much memory is dedicated to PostgreSQL for caching data.
 |===
 
-==== Template variables specific to *sso71-mysql-persistent*, *sso72-mysql-persistent*, *sso71-postgresql-persistent*, and *sso72-postgresql-persistent*
+==== Template variables specific to *sso72-mysql-persistent* and *sso72-postgresql-persistent*
 
 .Configuration Variables Specific To RH-SSO-enabled MySQL / PostgreSQL Applications With Persistent Storage
 [cols="2*", options="header"]
@@ -540,7 +540,7 @@ is provided.
 |*_SSO_USERNAME_*
 |The username used to access the RH-SSO service. This is used to create the
 application client(s) within the specified RH-SSO realm. This should match the
-*_SSO_SERVICE_USERNAME_* specified through one of the *sso71-* or *sso72-* templates.
+*_SSO_SERVICE_USERNAME_* specified through one of the *sso72-* templates.
 
 |*_SSO_PASSWORD_*
 |The password for the RH-SSO service user.


### PR DESCRIPTION

and corresponding application templates in the documentation

Note:

- Intentionally kept mention about RH-SSO 7.1 image and templates in the automated and manual DB migration sections,
- The x509 templates introduced within [CLOUD-2398](https://issues.jboss.org/browse/CLOUD-2398) will be described within separate docs PR for [KEYCLOAK-6650](https://issues.jboss.org/browse/KEYCLOAK-6650) JIRA, thus kept the change out for now

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>