### PR TITLE
[BZ1567846] Added location of RPM Based installation start script

### DIFF
--- a/getting_started/topics/first-boot/boot.adoc
+++ b/getting_started/topics/first-boot/boot.adoc
@@ -8,7 +8,13 @@ image:{project_images}/standalone-boot-files.png[]
 
 To boot the server:
 
-.Linux/Unix
+.Linux/Unix (rpm)
+[source]
+----
+$ /opt/rh/eap<EAP_VERSION>/root/usr/share/<VERSION_NAME>/bin/standalone.sh
+----
+
+.Linux/Unix (zip|tar)
 [source]
 ----
 $ .../bin/standalone.sh

--- a/server_installation/topics/operating-mode/standalone.adoc
+++ b/server_installation/topics/operating-mode/standalone.adoc
@@ -17,7 +17,13 @@ image:{project_images}/standalone-boot-files.png[]
 
 To boot the server:
 
-.Linux/Unix
+.Linux/Unix (rpm)
+[source]
+----
+$ /opt/rh/eap<EAP_VERSION>/root/usr/share/<VERSION_NAME>/bin/standalone.sh
+----
+
+.Linux/Unix (zip|tar)
 [source]
 ----
 $ .../bin/standalone.sh


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1567846. As you see on https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.1/html/server_installation_and_configuration_guide/operating-mode there is no clue about the binaries location, this MR solves that on the RPM installation based.