### PR TITLE
KEYCLOAK-7241 providers directory no longer exists

### DIFF
--- a/server_development/topics/auth-spi.adoc
+++ b/server_development/topics/auth-spi.adoc
@@ -440,7 +440,7 @@ org.keycloak.examples.authenticator.SecretQuestionRequiredActionFactory
 
 This services/ file is used by Keycloak to scan the providers it has to load into the system. 
 
-To deploy this jar, just copy it to the providers directory. 
+To deploy this jar, just copy it to the `standalone/deployments` directory. 
 
 ==== Implement the RequiredActionProvider
 
@@ -713,7 +713,7 @@ org.keycloak.authentication.forms.RegistrationRecaptcha
 
 This services/ file is used by Keycloak to scan the providers it has to load into the system. 
 
-To deploy this jar, just copy it to the providers directory. 
+To deploy this jar, just copy it to the `standalone/deployments` directory. 
 
 ==== Adding FormAction to the Registration Flow
 


### PR DESCRIPTION
The providers directory has been removed so use the standalone/deployments directory instead (KEYCLOAK-7241).