### PR TITLE
Javascript Adapter - Documentation about login options 'cordovaOptions'

### DIFF
--- a/securing_apps/topics/oidc/javascript-adapter.adoc
+++ b/securing_apps/topics/oidc/javascript-adapter.adoc
@@ -271,6 +271,7 @@ Options is an Object, where:
 * action - If value is 'register' then user is redirected to registration page, otherwise to login page.
 * locale - Sets the 'ui_locales' query param in compliance with section 3.1.2.1 of the OIDC 1.0 specification.
 * kcLocale - Specifies the desired Keycloak locale for the UI.  This differs from the locale param in that it tells the Keycloak server to set a cookie and update the user's profile to a new preferred locale.
+* cordovaOptions - Specifies the arguments that are passed to the Cordova in-app-browser (if applicable). Options `hidden` and `location` are not affected by these arguments. All available options are defined at https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-inappbrowser/. Example of use: `{ zoom: "no", hardwareback: "yes" }`;
 
 ====== createLoginUrl(options)
 


### PR DESCRIPTION
The documentation related to [KEYCLOAK-6655](https://issues.jboss.org/browse/KEYCLOAK-6655) was missing.