### PR TITLE
adding template information to contributors guide

### DIFF
--- a/internal_resources/contributing.adoc
+++ b/internal_resources/contributing.adoc
@@ -3,7 +3,7 @@
 
 This guide will help new contributors use `git` and GitHub for Keycloak documentation submissions and suggestions.
 
-Before you start, please take a look at our writing templates contained in the link:https://github.com/keycloak/keycloak-documentation/tree/master/internal_resources[internal resources directory], which also describes each template file with information about when to use which. We are working to update our documentation to match the style of these templates and request that new contributions please use the format and style in them.
+Before you start, please take a look at our writing templates contained in the link:https://github.com/keycloak/keycloak-documentation/tree/master/internal_resources[internal resources directory], which also describes each template file with information about when to use which. We are working to update our documentation to put procedural content, conceptual content, and reference content into separate .adoc files, and we kindly request that new contributions please use these templates.
 
 There are two ways to start. The first is the easiest, but it is less flexible. The second is more powerful, but requires setting up. For either method, you must already have a GitHub account, as described in link:https://github.com/join[Join GitHub].
 

--- a/internal_resources/contributing.adoc
+++ b/internal_resources/contributing.adoc
@@ -3,6 +3,8 @@
 
 This guide will help new contributors use `git` and GitHub for Keycloak documentation submissions and suggestions.
 
+Before you start, please take a look at our writing templates contained in the link:https://github.com/keycloak/keycloak-documentation/tree/master/internal_resources[internal resources directory], which also describes each template file with information about when to use which. We are working to update our documentation to match the style of these templates and request that new contributions please use the format and style in them.
+
 There are two ways to start. The first is the easiest, but it is less flexible. The second is more powerful, but requires setting up. For either method, you must already have a GitHub account, as described in link:https://github.com/join[Join GitHub].
 
 [[simple]]


### PR DESCRIPTION
The templates should be called out in the contributor's guide more clearly as we are trying to clean up our overall writing standards and style.