### PR TITLE
Patch about auth and token endpoint

### DIFF
--- a/server_admin/topics/sso-protocols/oidc.adoc
+++ b/server_admin/topics/sso-protocols/oidc.adoc
@@ -95,10 +95,10 @@ Here's a list of OIDC endpoints that the {project_name} publishes.  These URLs a
 talk OIDC with the auth server.  These are all relative URLs and the root of the URL being the HTTP(S) protocol, hostname, and usually path prefixed with
 _/auth_:  i.e. $$https://localhost:8080/auth$$
 
-/realms/{realm-name}/protocol/openid-connect/token::
+/realms/{realm-name}/protocol/openid-connect/auth::
   This is the URL endpoint for obtaining a temporary code in the Authorization Code Flow or for obtaining tokens via the
   Implicit Flow, Direct Grants, or Client Grants.
-/realms/{realm-name}/protocol/openid-connect/auth::
+/realms/{realm-name}/protocol/openid-connect/token::
   This is the URL endpoint for the Authorization Code Flow to turn a temporary code into a token.
 /realms/{realm-name}/protocol/openid-connect/logout::
   This is the URL endpoint for performing logouts.


### PR DESCRIPTION
I think the definitions of auth and token OIDC endpoints have been inverted