### PR TITLE
Update before.adoc

### DIFF
--- a/getting_started/topics/secure-jboss-app/before.adoc
+++ b/getting_started/topics/secure-jboss-app/before.adoc
@@ -3,7 +3,7 @@
 
 Before you can secure a Java servlet application, you must complete the installation of {project_name} and create the initial admin user as shown in  <<_install-boot, Installing and Booting>>.
 
-There is one caveat: you must run a separate {appserver_name} instance on the same machine as the {project_name} server to run your Java servlet application. Run the {project_name} using a different port than the {appserver_name}, to avoid port conflicts.
+There is one caveat: Even though {appserver_name} is bundled with keycloak, you cannot use this as an application container.  Instead, you must run a separate {appserver_name} instance on the same machine as the {project_name} server to run your Java servlet application. Run the {project_name} using a different port than the {appserver_name}, to avoid port conflicts.
 
 To adjust the port used, change the value of the `jboss.socket.binding.port-offset` system property when starting the server from the command line. The value of this property is a number that will be added to the base value of every port opened by the {project_name} server.
 


### PR DESCRIPTION
I was confused when I saw that wildfly also ran as part of keycloak and that I was able to deploy to it.  Then afterwards I realised that I should have downloaded a separate instance, but then I was stuck with two vanillas, one on the keycloak wildfly and one on the downloaded wildfly.  Putting in an acknowledgement of the existence of wildfly on the keycloak installation might help alleviate confusion.