### PR TITLE
Admin tool: Add documentation for adding roles to groups

### DIFF
--- a/securing_apps/topics/token-exchange/token-exchange.adoc
+++ b/securing_apps/topics/token-exchange/token-exchange.adoc
@@ -17,7 +17,7 @@ to impersonate a user.  Here's a short summary of the current capabilities of {p
 * A client can exchange an external token for a {project_name} token.
 * A client can impersonate a user
 
-Token exchange in {project_name} is a very loose implementation of the link:https://www.ietf.org/id/draft-ietf-oauth-token-exchange-14.txt[OAuth Token Exchange] specification at the IETF.
+Token exchange in {project_name} is a very loose implementation of the link:https://www.ietf.org/id/draft-ietf-oauth-token-exchange-15.txt[OAuth Token Exchange] specification at the IETF.
 We have extended it a little, ignored some of it, and loosely interpreted other parts of the specification.  It is
 a simple grant type invocation on a realm's OpenID Connect token endpoint.
 
@@ -72,7 +72,7 @@ NOTE:   We currently only support OpenID Connect and OAuth exchanges.  Support f
 
 A successful response from an exchange invocation will return the HTTP 200 response code with a content type that
 depends on the `requested-token-type` and `requested_issuer` the client asks for.  OAuth requested token types will return
-a JSON document as described in the link:https://www.ietf.org/id/draft-ietf-oauth-token-exchange-14.txt[OAuth Token Exchange] specification.
+a JSON document as described in the link:https://www.ietf.org/id/draft-ietf-oauth-token-exchange-15.txt[OAuth Token Exchange] specification.
 
 [source,json]
 ----

--- a/server_admin/topics/admin-cli.adoc
+++ b/server_admin/topics/admin-cli.adoc
@@ -789,6 +789,28 @@ Use the following example to remove two roles defined on the client [command]`re
 $ kcadm.sh remove-roles -r demorealm --rname testrole --cclientid realm-management --rolename create-client --rolename view-users
 ----
 
+[discrete]
+==== Adding client roles to a group
+
+Use a dedicated [command]`add-roles` command that can be used for adding realm roles and client roles.
+
+The following example adds the roles defined on the client [command]`realm-management` - `create-client` role and the [command]`view-users` role to the [command]`Testgroup` group (via the [command]`--gname` option). The group can alternatively be specified by ID (via the [command]`--gid` option).
+[options="nowrap"]
+----
+$ kcadm.sh add-roles -r demorealm --gname Testgroup --cclientid realm-management --rolename create-client --rolename view-users
+----
+
+[discrete]
+==== Removing client roles from a group
+
+Use a dedicated [command]`remove-roles` command to remove client roles from a group.
+
+Use the following example to remove two roles defined on the client [command]`realm management` - `create-client` role and the [command]`view-users` role from the [command]`Testgroup` group.
+[options="nowrap"]
+----
+$ kcadm.sh remove-roles -r demorealm --gname Testgroup --cclientid realm-management --rolename create-client --rolename view-users
+----
+
 
 === Client operations
 

--- a/server_admin/topics/admin-cli.adoc
+++ b/server_admin/topics/admin-cli.adoc
@@ -794,10 +794,10 @@ $ kcadm.sh remove-roles -r demorealm --rname testrole --cclientid realm-manageme
 
 Use a dedicated [command]`add-roles` command that can be used for adding realm roles and client roles.
 
-The following example adds the roles defined on the client [command]`realm-management` - `create-client` role and the [command]`view-users` role to the [command]`Testgroup` group (via the [command]`--gname` option). The group can alternatively be specified by ID (via the [command]`--gid` option).
+The following example adds the roles defined on the client [command]`realm-management` - `create-client` role and the [command]`view-users` role to the [command]`Group` group (via the [command]`--gname` option). The group can alternatively be specified by ID (via the [command]`--gid` option).
 [options="nowrap"]
 ----
-$ kcadm.sh add-roles -r demorealm --gname Testgroup --cclientid realm-management --rolename create-client --rolename view-users
+$ kcadm.sh add-roles -r demorealm --gname Group --cclientid realm-management --rolename create-client --rolename view-users
 ----
 
 [discrete]
@@ -805,10 +805,10 @@ $ kcadm.sh add-roles -r demorealm --gname Testgroup --cclientid realm-management
 
 Use a dedicated [command]`remove-roles` command to remove client roles from a group.
 
-Use the following example to remove two roles defined on the client [command]`realm management` - `create-client` role and the [command]`view-users` role from the [command]`Testgroup` group.
+Use the following example to remove two roles defined on the client [command]`realm management` - `create-client` role and the [command]`view-users` role from the [command]`Group` group.
 [options="nowrap"]
 ----
-$ kcadm.sh remove-roles -r demorealm --gname Testgroup --cclientid realm-management --rolename create-client --rolename view-users
+$ kcadm.sh remove-roles -r demorealm --gname Group --cclientid realm-management --rolename create-client --rolename view-users
 ----
 
 

--- a/server_admin/topics/admin-cli.adoc
+++ b/server_admin/topics/admin-cli.adoc
@@ -795,6 +795,8 @@ $ kcadm.sh remove-roles -r demorealm --rname testrole --cclientid realm-manageme
 Use a dedicated [command]`add-roles` command that can be used for adding realm roles and client roles.
 
 The following example adds the roles defined on the client [command]`realm-management` - `create-client` role and the [command]`view-users` role to the [command]`Group` group (via the [command]`--gname` option). The group can alternatively be specified by ID (via the [command]`--gid` option).
+
+See <<_group_operations, Group operations>> for more operations that can be performed to groups.
 [options="nowrap"]
 ----
 $ kcadm.sh add-roles -r demorealm --gname Group --cclientid realm-management --rolename create-client --rolename view-users
@@ -806,6 +808,8 @@ $ kcadm.sh add-roles -r demorealm --gname Group --cclientid realm-management --r
 Use a dedicated [command]`remove-roles` command to remove client roles from a group.
 
 Use the following example to remove two roles defined on the client [command]`realm management` - `create-client` role and the [command]`view-users` role from the [command]`Group` group.
+
+See <<_group_operations, Group operations>> for more operations that can be performed to groups.
 [options="nowrap"]
 ----
 $ kcadm.sh remove-roles -r demorealm --gname Group --cclientid realm-management --rolename create-client --rolename view-users
@@ -1183,6 +1187,7 @@ $ kcadm.sh create users/6da5ab89-3397-4205-afaa-e201ff638f9e/logout -r demorealm
 ----
 
 
+[[_group_operations]]
 === Group operations
 
 [discrete]


### PR DESCRIPTION
Hi there, thanks for this project.

I noticed that the [`kcadm.sh add-roles` documentation](https://github.com/keycloak/keycloak-documentation/blob/911336913b959e7d728b5c198b102b2ca239c70c/server_admin/topics/admin-cli.adoc#adding-client-roles-to-a-realm-role) was lacking when it came to [adding roles to groups](https://github.com/keycloak/keycloak/blob/8a5428808e3570744ea78fccffa23d8596b76e3f/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/commands/AddRolesCmd.java#L198-L225).

This pull request adds a couple of quick examples to try to address this.