### PR TITLE
Fixing a typo

### DIFF
--- a/securing_apps/topics/oidc/javascript-adapter.adoc
+++ b/securing_apps/topics/oidc/javascript-adapter.adoc
@@ -395,7 +395,7 @@ For example:
 [source,javascript]
 ----
 keycloak.loadUserProfile().then(function(profile) {
-        alert(JSON.stringify(test, null, "  "));
+        alert(JSON.stringify(profile, null, "  "));
     }).catch(function() {
         alert('Failed to load user profile');
     });


### PR DESCRIPTION
was: alert(JSON.stringify(test, null, "  "));
now: alert(JSON.stringify(profile, null, "  "));