### PR TITLE
?html is not allowed when auto-escaping is on

### DIFF
--- a/server_development/topics/custom-attributes.adoc
+++ b/server_development/topics/custom-attributes.adoc
@@ -41,7 +41,7 @@ As an example to add a mobile number to the account page add the following snipp
    </div>
 
    <div class="col-sm-10 col-md-10">
-       <input type="text" class="form-control" id="user.attributes.mobile" name="user.attributes.mobile" value="${(account.attributes.mobile!'')?html}"/>
+       <input type="text" class="form-control" id="user.attributes.mobile" name="user.attributes.mobile" value="${(account.attributes.mobile!'')}"/>
    </div>
 </div>
 ----


### PR DESCRIPTION
Keycloak v.4.6.0
Caused by: freemarker.core.ParseException: Syntax error in template "account.ftl" in line 66, column 143:                           
Using ?html (legacy escaping) is not allowed when auto-escaping is on with a markup output format (HTML), to avoid double-escaping m
istakes