### PR TITLE
KEYCLOAK-8610 nits in Getting Started guide

### DIFF
--- a/getting_started/topics/secure-jboss-app/install-client-adapter.adoc
+++ b/getting_started/topics/secure-jboss-app/install-client-adapter.adoc
@@ -13,9 +13,39 @@ endif::[]
 
 Extract the contents of this file into the root directory of your {appserver_name} distribution.
 
-ifeval::[{project_community}==true]
 Run the appropriate script for your platform:
 
+ifeval::[{project_product}==true]
+.EAP 6.3 and Linux/Unix
+[source,bash,subs=+attributes]
+----
+$ cd bin
+$ ./jboss-cli.sh --file=adapter-install-offline.cli
+----
+
+.EAP 6.3 and Windows
+[source,bash,subs=+attributes]
+----
+> cd bin
+> jboss-cli.bat --file=adapter-install-offline.cli
+----
+
+.EAP 7.2.5 and Linux/Unix
+[source,bash,subs=+attributes]
+----
+$ cd bin
+$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli
+----
+
+.EAP 7.2.5 and Windows
+[source,bash,subs=+attributes]
+----
+> cd bin
+> jboss-cli.bat --file=adapter-elytron-install-offline.cli
+----
+endif::[]
+
+ifeval::[{project_community}==true]
 .WildFly 10 and Linux/Unix
 [source,bash,subs=+attributes]
 ----
@@ -43,9 +73,10 @@ $ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli
 > cd bin
 > jboss-cli.bat --file=adapter-elytron-install-offline.cli
 ----
+endif::[]
 
 NOTE: This script will make the necessary edits to the `.../standalone/configuration/standalone.xml` file of your app server distribution and may take some time to complete.
-endif::[]
+
 
 Start the application server.
 

--- a/getting_started/topics/secure-jboss-app/install-client-adapter.adoc
+++ b/getting_started/topics/secure-jboss-app/install-client-adapter.adoc
@@ -13,6 +13,7 @@ endif::[]
 
 Extract the contents of this file into the root directory of your {appserver_name} distribution.
 
+ifeval::[{project_community}==true]
 Run the appropriate script for your platform:
 
 .WildFly 10 and Linux/Unix
@@ -29,7 +30,6 @@ $ ./jboss-cli.sh --file=adapter-install-offline.cli
 > jboss-cli.bat --file=adapter-install-offline.cli
 ----
 
-ifeval::[{project_community}==true]
 .Wildfly 11 and Linux/Unix
 [source,bash,subs=+attributes]
 ----
@@ -43,9 +43,9 @@ $ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli
 > cd bin
 > jboss-cli.bat --file=adapter-elytron-install-offline.cli
 ----
-endif::[]
 
 NOTE: This script will make the necessary edits to the `.../standalone/configuration/standalone.xml` file of your app server distribution and may take some time to complete.
+endif::[]
 
 Start the application server.
 


### PR DESCRIPTION
The reference to the red button is removed from the text, but the screenshot is not yet updated. We are in the process of refreshing the UI and will retake all screenshots at that time.

I definitely want engineering to take a close look and confirm that this part is okay: I widened the if statement to cover all the aspects that I believe should be community-only to remove them from the RH-SSO docs. I believe this takes care of the second part of the issue, but want to make sure I was not overzealous.