### PR TITLE
Add documentation for enable-authorization-header

### DIFF
--- a/securing_apps/topics/oidc/keycloak-gatekeeper.adoc
+++ b/securing_apps/topics/oidc/keycloak-gatekeeper.adoc
@@ -271,6 +271,8 @@ if r.config.EnableAuthorizationHeader {
 }
 ----
 
+To control the `Authorization` header use the `enable-authorization-header` yaml configuration or the `--enable-authorization-header` command line option. By default this option is set to `true`.
+
 ==== Custom claim headers
 
 You can inject additional claims from the access token into the authorization headers with the `--add-claims` option. For example, a token from a {project_name} provider might include the following claims:


### PR DESCRIPTION
To me it was not really documented that the header was set by default. Maybe this is helpful for other people?