### PR TITLE
KEYCLOAK-9325 updates to upgrading guide

### DIFF
--- a/upgrading/topics/migrate_themes.adoc
+++ b/upgrading/topics/migrate_themes.adoc
@@ -19,6 +19,7 @@ In summary:
 ifeval::[{project_product}==true]
 Each step is described in more detail below the list of changes.
 
+include::rhsso/migrate_themes-changes-73.adoc[leveloffset=0]
 include::rhsso/migrate_themes-changes-72.adoc[leveloffset=0]
 include::rhsso/migrate_themes-changes-71.adoc[leveloffset=0]
 endif::[]

--- a/upgrading/topics/rhsso/changes-72.adoc
+++ b/upgrading/topics/rhsso/changes-72.adoc
@@ -48,11 +48,11 @@ described in <<_compatibility_with_older_adapters>>. There is the `Exclude Sessi
 which can be turned on to prevent adding the `session_state` parameter to the Authentication Response.
 
 === Microsoft Identity Provider updated to use the Microsoft Graph API
-
-The Microsoft Identity Provider implementation in {project_name} up to version 7.2.4 relies on the Live SDK
+ 
+The Microsoft Identity Provider implementation in {project_name} used to rely on the Live SDK
 endpoints for authorization and obtaining the user profile. From November 2018 onwards, Microsoft is removing support
 for the Live SDK API in favor of the new Microsoft Graph API. The {project_name} identity provider has been updated
-to use the new endpoints so if this integration is in use make sure you upgrade to {project_name} version 7.2.5 or later.
+to use the new endpoints so if this integration is in use make sure you upgrade to the latest {project_name} version.
 
 Legacy client applications registered under "Live SDK applications" won't work with the Microsoft Graph endpoints
 due to changes in the id format of the applications. If you run into an error saying that the application identifier
@@ -61,10 +61,10 @@ https://account.live.com/developers/applications/create[Microsoft Application Re
 
 === Google Identity Provider updated to use Google Sign-in authentication system
 
-The Google Identity Provider implementation in {project_name} up to version 7.2.5 relies on the Google+ API endpoints
+The Google Identity Provider implementation in {project_name} used to rely on the Google+ API endpoints
 endpoints for authorization and obtaining the user profile. From March 2019 onwards, Google is removing support
 for the Google+ API in favor of the new Google Sign-in authentication system. The {project_name} identity provider has been updated
-to use the new endpoints so if this integration is in use make sure you upgrade to {project_name} version 7.2.6 or later.
+to use the new endpoints so if this integration is in use make sure you upgrade to the latest {project_name} version.
 
 If you run into an error saying that the application identifier was not found in the directory, you will have to register the client application again in the
 https://console.developers.google.com/apis/credentials[Google API Console] portal to obtain a new application id and secret.

--- a/upgrading/topics/rhsso/changes-72.adoc
+++ b/upgrading/topics/rhsso/changes-72.adoc
@@ -48,11 +48,11 @@ described in <<_compatibility_with_older_adapters>>. There is the `Exclude Sessi
 which can be turned on to prevent adding the `session_state` parameter to the Authentication Response.
 
 === Microsoft Identity Provider updated to use the Microsoft Graph API
- 
-The Microsoft Identity Provider implementation in {project_name} used to rely on the Live SDK
+
+The Microsoft Identity Provider implementation in {project_name} up to version 7.2.4 relies on the Live SDK
 endpoints for authorization and obtaining the user profile. From November 2018 onwards, Microsoft is removing support
 for the Live SDK API in favor of the new Microsoft Graph API. The {project_name} identity provider has been updated
-to use the new endpoints so if this integration is in use make sure you upgrade to the latest {project_name} version.
+to use the new endpoints so if this integration is in use make sure you upgrade to {project_name} version 7.2.5 or later.
 
 Legacy client applications registered under "Live SDK applications" won't work with the Microsoft Graph endpoints
 due to changes in the id format of the applications. If you run into an error saying that the application identifier
@@ -61,10 +61,10 @@ https://account.live.com/developers/applications/create[Microsoft Application Re
 
 === Google Identity Provider updated to use Google Sign-in authentication system
 
-The Google Identity Provider implementation in {project_name} used to rely on the Google+ API endpoints
+The Google Identity Provider implementation in {project_name} up to version 7.2.5 relies on the Google+ API endpoints
 endpoints for authorization and obtaining the user profile. From March 2019 onwards, Google is removing support
 for the Google+ API in favor of the new Google Sign-in authentication system. The {project_name} identity provider has been updated
-to use the new endpoints so if this integration is in use make sure you upgrade to the latest {project_name} version.
+to use the new endpoints so if this integration is in use make sure you upgrade to {project_name} version 7.2.6 or later.
 
 If you run into an error saying that the application identifier was not found in the directory, you will have to register the client application again in the
 https://console.developers.google.com/apis/credentials[Google API Console] portal to obtain a new application id and secret.

--- a/upgrading/topics/rhsso/changes-73.adoc
+++ b/upgrading/topics/rhsso/changes-73.adoc
@@ -126,11 +126,11 @@ the native promise. This was causing issues as the error handler was not always 
 resulted in `Uncaught (in promise)` error.
 
 === Microsoft Identity Provider updated to use the Microsoft Graph API
-
-The Microsoft Identity Provider implementation in {project_name} up to version 7.2 relies on the Live SDK
+ 
+The Microsoft Identity Provider implementation in {project_name} used to rely on the Live SDK
 endpoints for authorization and obtaining the user profile. From November 2018 onwards, Microsoft is removing support
 for the Live SDK API in favor of the new Microsoft Graph API. The {project_name} identity provider has been updated
-to use the new endpoints so if this integration is in use make sure you upgrade to {project_name} version 7.3 or later.
+to use the new endpoints so if this integration is in use make sure you upgrade to the latest {project_name} version.
 
 Legacy client applications registered under "Live SDK applications" won't work with the Microsoft Graph endpoints
 due to changes in the id format of the applications. If you run into an error saying that the application identifier
@@ -139,10 +139,10 @@ https://account.live.com/developers/applications/create[Microsoft Application Re
 
 === Google Identity Provider updated to use Google Sign-in authentication system
 
-The Google Identity Provider implementation in {project_name} up to version 7.2.5 relies on the Google+ API endpoints
+The Google Identity Provider implementation in {project_name} used to rely on the Google+ API endpoints
 endpoints for authorization and obtaining the user profile. From March 2019 onwards, Google is removing support
 for the Google+ API in favor of the new Google Sign-in authentication system. The {project_name} identity provider has been updated
-to use the new endpoints so if this integration is in use make sure you upgrade to {project_name} version 7.2.6 or later.
+to use the new endpoints so if this integration is in use make sure you upgrade to the latest {project_name} version.
 
 If you run into an error saying that the application identifier was not found in the directory, you will have to register the client application again in the
 https://console.developers.google.com/apis/credentials[Google API Console] portal to obtain a new application id and secret.

--- a/upgrading/topics/rhsso/changes-73.adoc
+++ b/upgrading/topics/rhsso/changes-73.adoc
@@ -103,11 +103,11 @@ specific {project_name} server functionality, but there are few changes related 
   Cross-Datacenter Replication changes::
     * You will need to upgrade {jdgserver_name} server to version {jdgserver_version}. The older version may still work, but it is
     not guaranteed as we don't test it anymore.
-  ifeval::[{project_product}==true]
+ifeval::[{project_product}==true]
     * There is a need to add `protocolVersion` property with the value `2.6` to the configuration of the `remote-store` element in the
     {project_name} configuration. This is required as there is a need to downgrade the version of HotRod protocol to be compatible
     with the version used by {jdgserver_name} {jdgserver_version}.
-  endif::[]
+endif::[]
 
 === Hostname configuration
 
@@ -127,10 +127,10 @@ resulted in `Uncaught (in promise)` error.
 
 === Microsoft Identity Provider updated to use the Microsoft Graph API
 
-The Microsoft Identity Provider implementation in {project_name} up to version 4.5.0 relies on the Live SDK
+The Microsoft Identity Provider implementation in {project_name} up to version 7.2 relies on the Live SDK
 endpoints for authorization and obtaining the user profile. From November 2018 onwards, Microsoft is removing support
 for the Live SDK API in favor of the new Microsoft Graph API. The {project_name} identity provider has been updated
-to use the new endpoints so if this integration is in use make sure you upgrade to {project_name} version 4.6.0 or later.
+to use the new endpoints so if this integration is in use make sure you upgrade to {project_name} version 7.3 or later.
 
 Legacy client applications registered under "Live SDK applications" won't work with the Microsoft Graph endpoints
 due to changes in the id format of the applications. If you run into an error saying that the application identifier

--- a/upgrading/topics/rhsso/migrate_themes-changes-73.adoc
+++ b/upgrading/topics/rhsso/migrate_themes-changes-73.adoc
@@ -1,0 +1,59 @@
+===== Theme changes RH-SSO 7.3
+
+**Templates**
+
+* Account: account.ftl
+* Account: applications.ftl
+* Account: resource-detail.ftl (new)
+* Account: resources.ftl (new)
+* Account: template.ftl
+* Account: totp.ftl
+* Email-html: email-test.ftl
+* Email-html: email-verification-with-code.ftl (new)
+* Email-html: email-verification.ftl
+* Email-html: event-login_error.ftl
+* Email-html: event-removed_totp.ftl
+* Email-html: event-update_password.ftl
+* Email-html: event-update_totp.ftl
+* Email-html: executeActions.ftl
+* Email-html: identity-provider-link.ftl
+* Email-html: password-reset.ftl
+* Email-text: email-verification-with-code.ftl (new)
+* Email-text: email-verification.ftl
+* Email-text: executeActions.ftl
+* Email-text: identity-provider-link.ftl
+* Email-text: password-reset.ftl
+* Login: cli_splash.ftl (new)
+* Login: code.ftl
+* Login: error.ftl
+* Login: info.ftl
+* Login: login-config-totp-text.ftl (new)
+* Login: login-config-totp.ftl
+* Login: login-idp-link-confirm.ftl
+* Login: login-idp-link-email.ftl
+* Login: login-oauth-grant.ftl
+* Login: login-page-expired.ftl
+* Login: login-reset-password.ftl
+* Login: login-totp.ftl
+* Login: login-update-password.ftl
+* Login: login-update-profile.ftl
+* Login: login-verify-email-code-text.ftl (new)
+* Login: login-verify-email.ftl
+* Login: login-x509-info.ftl
+* Login: login.ftl
+* Login: register.ftl
+* Login: template.ftl
+* Login: terms.ftl
+* Welcome: index.ftl (new)
+
+**Messages**
+
+* Account: messages_en.properties
+* Admin: admin-messages_en.properties
+* Email: messages_en.properties
+* Login: messages_en.properties 
+
+**Styles**
+
+* Login: login-rhsso.css (new)
+* Welcome: welcome-rhsso.css


### PR DESCRIPTION
Still need to update EAP URL from 7.0 to 7.2, but must wait until EAP releases.

Still need content to write about theme migration/changes.