### PR TITLE
Remove paragraph in Token Exchange doc

### DIFF
--- a/securing_apps/topics/token-exchange/token-exchange.adoc
+++ b/securing_apps/topics/token-exchange/token-exchange.adoc
@@ -3,10 +3,6 @@
 
 == Token Exchange
 
-:tech_feature_name: Token Exchange
-:tech_feature_setting: -Dkeycloak.profile.feature.token_exchange=enabled
-include::../templates/techpreview.adoc[]
-
 In {project_name}, token exchange is the process of using a set of credentials or token to obtain an entirely different token.
 A client may want to invoke on a less trusted application so it may want to downgrade the current token it has.
 A client may want to exchange a {project_name} token for a token stored for a linked social provider account.


### PR DESCRIPTION
Remove "Token Exchange is Technology Preview and is not fully supported." paragraph from the latest Keycloak documentation as Token Exchange is not Technology Preview anymore.

![image](https://user-images.githubusercontent.com/5966800/52273485-ebf7a800-2941-11e9-83fe-2963e6da7ba1.png)
