### PR TITLE
docs(server-admin): Documenting OIDC user session note mappers

### DIFF
--- a/server_admin/topics/clients/protocol-mappers.adoc
+++ b/server_admin/topics/clients/protocol-mappers.adoc
@@ -51,3 +51,20 @@ implementations are processed in the needed order.
 
 For example, when we first want to compute the roles which will be included with a token, we first resolve audiences based on
 those roles. Then, we process a JavaScript script that uses the roles and audiences already available in the token.
+
+[[_protocol-mappers_oidc-user-session-note-mappers]]
+==== OIDC User Session Note Mappers
+
+User session details are via mappers and depend on various criteria. User session details are automatically included when you use or enable a feature on a client. You can also click the `Add builtin` button to include session details.
+
+Impersonated user sessions provide the following details:
+
+* `IMPERSONATOR_ID`: The ID of an impersonating user
+* `IMPERSONATOR_USERNAME`: The username of an impersonating user
+
+Service account sessions provide the following details:
+
+* `clientId`: The client ID of the service account
+* `clientAddress`: The remote host IP of the service account authenticated device
+* `clientHost`: The remote host name of the service account authenticated device
+


### PR DESCRIPTION
Related: https://github.com/keycloak/keycloak/pull/5096

- Documents new and existing OIDC user session note mappers.