### PR TITLE
script authenticators are not enabled by default

### DIFF
--- a/server_installation/topics/profiles.adoc
+++ b/server_installation/topics/profiles.adoc
@@ -51,9 +51,9 @@ endif::[]
 |No
 |Preview
 
-|script
+|scripts
 |Write custom authenticators using JavaScript
-|Yes
+|No
 |Preview
 
 |token_exchange


### PR DESCRIPTION
"script" authenticators are called "scripts" when editing the profile.properties and looking at server info. They are not enabled by default. (at least not in 4.8.3.Final. I haven't had a chance to test today's release of 5.0.0)