### PR TITLE
KEYCLOAK-4249 - Make IDP URL in keycloak-saml.xml configurable

### DIFF
--- a/securing_apps/topics/saml/java/general-config/idp_element.adoc
+++ b/securing_apps/topics/saml/java/general-config/idp_element.adoc
@@ -31,4 +31,5 @@ signatureAlgorithm::
 signatureCanonicalizationMethod::
   This is the signature canonicalization method that the IDP expects signed documents to use.  This setting is  _OPTIONAL_.
   The default value is `\http://www.w3.org/2001/10/xml-exc-c14n#` and should be good for most IDPs.
-
+metadataUrl::
+  The URL used to retrieve the IDP metadata, currently this is only used to pick up signing and encryption keys periodically which allow cycling of these keys on the IDP without manual changes on the SP side.

--- a/topics/templates/document-attributes-community.adoc
+++ b/topics/templates/document-attributes-community.adoc
@@ -100,6 +100,6 @@
 :subsystem_undertow_xml_urn: urn:jboss:domain:undertow:8.0
 :subsystem_infinispan_xml_urn: urn:jboss:domain:infinispan:8.0
 :subsystem_datasources_xml_urn: urn:jboss:domain:datasources:5.0
-:saml_adapter_xsd_urn: https://www.keycloak.org/schema/keycloak_saml_adapter_1_9.xsd
+:saml_adapter_xsd_urn: https://www.keycloak.org/schema/keycloak_saml_adapter_1_10.xsd
 :generic_adapter_name: keycloak-gatekeeper
 :generic_adapter_name_full: Keycloak Gatekeeper

--- a/topics/templates/document-attributes-product.adoc
+++ b/topics/templates/document-attributes-product.adoc
@@ -122,6 +122,6 @@ endif::[]
 :subsystem_undertow_xml_urn: urn:jboss:domain:undertow:6.0
 :subsystem_infinispan_xml_urn: urn:jboss:domain:infinispan:6.0
 :subsystem_datasources_xml_urn: urn:jboss:domain:datasources:5.0
-:saml_adapter_xsd_urn: https://www.keycloak.org/schema/keycloak_saml_adapter_1_9.xsd
+:saml_adapter_xsd_urn: https://www.keycloak.org/schema/keycloak_saml_adapter_1_10.xsd
 :generic_adapter_name: keycloak-gatekeeper
 :generic_adapter_name_full: Keycloak Gatekeeper


### PR DESCRIPTION
This pull request is related to https://github.com/keycloak/keycloak/pull/5934. @hmlnarik - Hopefully I have the required changes.

I have updated the references to the version of keycloak_saml_adapter schema to 1_10 and added the details of the metadataUrl to the IDP element docs.

