### PR TITLE
Fix link from Event Listener SPI to Service Provider Interfaces

### DIFF
--- a/server_development/topics/events.adoc
+++ b/server_development/topics/events.adoc
@@ -4,5 +4,5 @@
 Writing a Event Listener Provider starts by implementing the `EventListenerProvider` and `EventListenerProviderFactory` interfaces. Please see the Javadoc
 and examples for complete details on how to do this.
 
-For details on how to package and deploy a custom provider refer to the <<_providers,Service Provider Interfaces>> chapter.
+For details on how to package and deploy a custom provider refer to the link:providers.adoc#_providers[Service Provider Interfaces] chapter.
 


### PR DESCRIPTION
Link in <https://www.keycloak.org/docs/latest/server_development/index.html#_events> to <https://www.keycloak.org/docs/latest/server_development/index.html#_providers> is broken