### PR TITLE
KEYCLOAK-9966: Explain better how URL/Binding is selected for IDP iniated login

### DIFF
--- a/server_admin/topics/clients/saml/idp-initiated-login.adoc
+++ b/server_admin/topics/clients/saml/idp-initiated-login.adoc
@@ -6,6 +6,15 @@ In the `Settings` tab for your client, you need to specify the `IDP Initiated SS
 This is a simple string with no whitespace in it.
 After this you can reference your client at the following URL: `root/auth/realms/{realm}/protocol/saml/clients/{url-name}`
 
+The IDP initiated login implementation prefers _POST_ over _REDIRECT_ binding (check <<saml-bindings, saml bindings>> for more information).
+Therefore the final binding and SP URL are selected in the following way:
+
+1. If the specific `Assertion Consumer Service POST Binding URL` is defined (inside `Fine Grain SAML Endpoint Configuration` section
+of the client settings) _POST_ binding is used through that URL.
+2. If the general `Master SAML Processing URL` is specified then _POST_ binding is used again throught this general URL.
+3. As the last resort, if the `Assertion Consumer Service Redirect Binding URL` is configured (inside
+`Fine Grain SAML Endpoint Configuration`) _REDIRECT_ binding is used with this URL.
+
 If your client requires a special relay state, you can also configure this on the `Settings` tab in the `IDP Initiated SSO Relay State` field.
 Alternatively, browsers can specify the relay state in a `RelayState` query parameter, i.e.
 `root/auth/realms/{realm}/protocol/saml/clients/{url-name}?RelayState=thestate`.

--- a/server_admin/topics/sso-protocols/saml.adoc
+++ b/server_admin/topics/sso-protocols/saml.adoc
@@ -51,6 +51,11 @@ the {project_name} server or application when exchanging documents.  Basically H
 that contains an HTML form with embedded JavaScript.  When the page is loaded, the JavaScript automatically invokes the form.
 You really don't need to know about this stuff, but it is a pretty clever trick.
 
+_POST_ binding is usually recommended because of security and size restrictions. When using _REDIRECT_ the SAML response
+is part of the URL (it is a query parameter as it was explained before), so it can be captured in logs and it is considered
+less secure. Regarding size, if the assertion contains a lot or large attributes sending the document inside the HTTP payload
+is always better than in the more limited URL.
+
 ===== ECP
 
 ECP stands for "Enhanced Client or Proxy", a SAML v.2.0 profile which allows for the exchange of SAML attributes outside the context of a web browser.


### PR DESCRIPTION
Document a bit better how the IDP initiated logins selects final SP SAML processing URL and the binding (now it's possible to do that after KEYCLOAK-9068).
I'm very bad writing documentation, so any improvement you see please let me know.