### PR TITLE
Fix incorrect RP abbreviation

### DIFF
--- a/securing_apps/topics/oidc/oidc-generic.adoc
+++ b/securing_apps/topics/oidc/oidc-generic.adoc
@@ -1,6 +1,6 @@
 === Other OpenID Connect Libraries
 
-{project_name} can be secured by supplied adapters that are usually easier to use and provide better integration with {project_name}. However, if an adapter is not available for your programming language, framework, or platform you might opt to use a generic OpenID Connect Resource Provider (RP) library instead. This chapter describes details specific to {project_name} and does not contain specific protocol details. For more information see the https://openid.net/connect/[OpenID Connect specifications] and https://tools.ietf.org/html/rfc6749[OAuth2 specification].
+{project_name} can be secured by supplied adapters that are usually easier to use and provide better integration with {project_name}. However, if an adapter is not available for your programming language, framework, or platform you might opt to use a generic OpenID Connect Relying Party (RP) library instead. This chapter describes details specific to {project_name} and does not contain specific protocol details. For more information see the https://openid.net/connect/[OpenID Connect specifications] and https://tools.ietf.org/html/rfc6749[OAuth2 specification].
 
 ==== Endpoints
 

--- a/securing_apps/topics/oidc/oidc-overview.adoc
+++ b/securing_apps/topics/oidc/oidc-overview.adoc
@@ -1,4 +1,4 @@
 == OpenID Connect
 
 This section describes how you can secure applications and services with OpenID Connect using either {project_name} adapters or generic OpenID Connect
-Resource Provider libraries.
+Relying Party libraries.

--- a/securing_apps/topics/overview/overview.adoc
+++ b/securing_apps/topics/overview/overview.adoc
@@ -4,6 +4,6 @@
 decide is which of the two you are going to use. If you want you can also choose to secure some with OpenID Connect and others with SAML.
 
 To secure clients and services you are also going to need an adapter or library for the protocol you've selected. {project_name} comes with its own
-adapters for selected platforms, but it is also possible to use generic OpenID Connect Resource Provider and SAML Service Provider libraries.
+adapters for selected platforms, but it is also possible to use generic OpenID Connect Relying Party and SAML Service Provider libraries.
 
 

--- a/server_admin/topics/overview/features.adoc
+++ b/server_admin/topics/overview/features.adoc
@@ -26,4 +26,4 @@ endif::[]
 ifeval::[{project_product}==true]
 * Client adapters for JavaScript applications, JBoss EAP, Fuse, etc.
 endif::[]
-* Supports any platform/language that has an OpenID Connect Resource Provider library or SAML 2.0 Service Provider library.
+* Supports any platform/language that has an OpenID Connect Relying Party library or SAML 2.0 Service Provider library.


### PR DESCRIPTION
OpenID Connect RP abbreviation is not Resource Provider but Relying Party.