### PR TITLE
KEYCLOAK-5665 - elytron propagate security domain to ejb

### DIFF
--- a/securing_apps/topics/oidc/java/jboss-adapter.adoc
+++ b/securing_apps/topics/oidc/java/jboss-adapter.adoc
@@ -300,22 +300,4 @@ If you have multiple deployments secured by the same realm you can share the rea
 
 ===== Security Domain
 
-To propagate the security context to the EJB tier you need to configure it to use the "keycloak" security domain. This
-can be achieved with the @SecurityDomain annotation:
-
-[source,java]
-----
-
-import org.jboss.ejb3.annotation.SecurityDomain;
-...
-
-@Stateless
-@SecurityDomain("keycloak")
-public class CustomerService {
-
-    @RolesAllowed("user")
-    public List<String> getCustomers() {
-        return db.getCustomers();
-    }
-}
-----
+The security context is propagated to the EJB tier automatically.

--- a/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc
+++ b/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc
@@ -136,44 +136,7 @@ Otherwise this configuration is optional.
     </security-domains>
 ----
 
-For example, if you have a JAX-RS service that is an EJB within your WEB-INF/classes directory,
-you'll want to annotate it with the `@SecurityDomain` annotation as follows:
-
-[source,java]
-----
-
-import org.jboss.ejb3.annotation.SecurityDomain;
-import org.jboss.resteasy.annotations.cache.NoCache;
-
-import javax.annotation.security.RolesAllowed;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import java.util.ArrayList;
-import java.util.List;
-
-@Path("customers")
-@Stateless
-@SecurityDomain("keycloak")
-public class CustomerService {
-
-    @EJB
-    CustomerDB db;
-
-    @GET
-    @Produces("application/json")
-    @NoCache
-    @RolesAllowed("db_user")
-    public List<String> getCustomers() {
-        return db.getCustomers();
-    }
-}
-----
-
-We hope to improve our integration in the future so that you don't have to specify the
-`@SecurityDomain` annotation when you want to propagate a keycloak security context to the EJB tier.
+The security context is propagated to the EJB tier automatically.
 
 ===== JBoss SSO
 


### PR DESCRIPTION
Update documentation to indicate security context is now automatically propagated to EJB tier.

See:  https://github.com/keycloak/keycloak/pull/5977