### PR TITLE
fix-broken-heading

### DIFF
--- a/securing_apps/topics/oidc/keycloak-gatekeeper.adoc
+++ b/securing_apps/topics/oidc/keycloak-gatekeeper.adoc
@@ -518,4 +518,5 @@ Keep in mind link:http://browsercookielimits.squawky.net/[browser cookie limits]
 All cookies are part of the header request, so you might find a problem with the max headers size limits in your infrastructure (some load balancers have very low this value, such as 8 KB). Be sure that all network devices have sufficient header size limits. Otherwise, your users won't be able to obtain an access token.
 
 ==== Known Issues
-* There is a known issue with the Keycloak server 4.7.0.Final in which Gatekeeper is unable to find the _client_id_ in the _aud_ claim. This is due to the fact the _client_id_ is not in the audience anymore. The workaround is to add the "Audience" protocol mapper to the client with the audience pointed to the _client_id_. For more information, see link:https://issues.jboss.org/browse/KEYCLOAK-8954[KEYCLOAK-8954].
+
+There is a known issue with the Keycloak server 4.7.0.Final in which Gatekeeper is unable to find the _client_id_ in the _aud_ claim. This is due to the fact the _client_id_ is not in the audience anymore. The workaround is to add the "Audience" protocol mapper to the client with the audience pointed to the _client_id_. For more information, see link:https://issues.jboss.org/browse/KEYCLOAK-8954[KEYCLOAK-8954].

--- a/securing_apps/topics/oidc/mod-auth-openidc.adoc
+++ b/securing_apps/topics/oidc/mod-auth-openidc.adoc
@@ -1,5 +1,5 @@
 [[_mod_auth_openidc]]
-==== mod_auth_openidc Apache HTTPD Module
+=== mod_auth_openidc Apache HTTPD Module
 
 The https://github.com/zmartzone/mod_auth_openidc[mod_auth_openidc] is an Apache HTTP plugin for OpenID Connect. If your language/environment supports using Apache HTTPD
 as a proxy, then you can use _mod_auth_openidc_ to secure your web application with OpenID Connect.  Configuration of this module


### PR DESCRIPTION
The header of `mod_auth_openidc` is missing and its sentences are shown in Keycloak Gatekeeper section. So I fix its heading.