### PR TITLE
Remove reference to missing authenticator project example

### DIFF
--- a/server_development/topics/auth-spi.adoc
+++ b/server_development/topics/auth-spi.adoc
@@ -130,7 +130,7 @@ Let's walk through the steps from when a client first redirects to keycloak to a
 === Authenticator SPI Walk Through
 
 In this section, we'll take a look at the Authenticator interface.
-For this, we are going to implement an authenticator that requires that a user enter in the answer to a secret question like "What is your mother's maiden name?".  This example is fully implemented and contained in the examples/providers/authenticator directory of the demo distribution of Keycloak. 
+For this, we are going to implement an authenticator that requires that a user enter in the answer to a secret question like "What is your mother's maiden name?".
 
 The classes you must implement are the org.keycloak.authentication.AuthenticatorFactory and Authenticator interfaces.
 The Authenticator interface defines the logic.


### PR DESCRIPTION
examples/providers/authenticator is no more in repository as demo distribution has been removed (see KEYCLOAK-8437)