### PR TITLE
[KEYCLOAK-8043] Add documentation for the `Support prompt=none` confi…

### DIFF
--- a/server_admin/topics/identity-broker/oidc.adoc
+++ b/server_admin/topics/identity-broker/oidc.adoc
@@ -50,6 +50,17 @@ You must define the OpenID Connect configuration options as well.  They basicall
 |Another optional switch.  This is the prompt parameter defined by the OIDC specification. Through it you can force re-authentication and other options.  See the specification for
  more details.
 
+|Accepts prompt=none forward from client
+|Specifies whether the IDP accepts forwarded authentication requests that contain the prompt=none query parameter or not. When a realm receives an auth request with `prompt=none` it checks
+ if the user is currently authenticated and normally returns a `login_required` error if the user is not logged in. However, when a default IDP can be determined
+ for the auth request (either via `kc_idp_hint` query param or by setting up a default IDP for the realm) we should be able to forward the auth request with
+ `prompt=none` to the default IDP so that it checks if the user is currently authenticated there. Because not all IDPs support requests with `prompt=none` this switch
+ is used to indicate if the default IDP supports the param before redirecting the auth request.
+
+ It is important to note that if the user is not authenticated in the IDP, the client will still get a `login_required` error. Even if the user is currently authenticated in the IDP,
+ the client might still get an `interaction_required` error if authentication or consent pages requiring user interaction would be otherwise displayed. This includes required actions
+ (e.g. change password), consent screens and any screens set to be displayed by the `first broker login` flow or `post broker login` flow.
+
 |Validate Signatures
 |Another optional switch. This is to specify if {project_name} will verify the signatures on the external ID Token signed by this identity provider. If this is on,
 the {project_name} will need to know the public key of the external OIDC identity provider. See below for how to set it up.

--- a/upgrading/topics/keycloak/changes.adoc
+++ b/upgrading/topics/keycloak/changes.adoc
@@ -23,6 +23,20 @@ We have added a new `microprofile-jwt` optional client scope to handle the claim
 This new client scope defines protocol mappers to set the username of the authenticated user to the `upn` claim and to
 set the realm roles to the `groups` claim.
 
+==== Ability to propagate prompt=none to default IDP
+
+We have added a new switch in the OIDC identity provider configuration named `Accepts prompt=none forward from client` to identify IDPs that
+are able to handle forwarded requests that include the `prompt=none` query parameter.
+
+Until now, when receiving an auth request with `prompt=none` a realm would return a `login_required` error if the user is
+not authenticated in the realm without checking if the user has been authenticated by an IDP. From now on, if a default
+IDP can be determined for the auth request (either by the use of the `kc_idp_hint` query param or by setting up a default IDP
+for the realm) and if the `Accepts prompt=none forward from client` switch has been enabled for the IDP, the auth request is forwarded to the IDP
+to check if the user has been authenticated there.
+
+It is important to note that this switch is only taken into account if a default IDP is specified, in which case we know
+where to forward the auth request without having to prompt the user to select an IDP. If a default IDP cannot be determined
+we cannot assume which one will be used to fulfill the auth request so the request forwarding is not performed.
 
 === Migrating to 5.0.0
 


### PR DESCRIPTION
…guration switch now present in OIDC identity providers

Link to Jira: https://issues.jboss.org/browse/KEYCLOAK-8043