### PR TITLE
KEYCLOAK-10288 Fix warnings in build log, and one ccutils error

### DIFF
--- a/header-maven-plugin/pom.xml
+++ b/header-maven-plugin/pom.xml
@@ -50,7 +50,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>3.4</version>
                 <configuration>
-                    <goalPrefix>header-maven-plugin</goalPrefix>
+                    <goalPrefix>header</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
                 <executions>

--- a/server_admin/topics/clients/saml/idp-initiated-login.adoc
+++ b/server_admin/topics/clients/saml/idp-initiated-login.adoc
@@ -6,7 +6,7 @@ In the `Settings` tab for your client, you need to specify the `IDP Initiated SS
 This is a simple string with no whitespace in it.
 After this you can reference your client at the following URL: `root/auth/realms/{realm}/protocol/saml/clients/{url-name}`
 
-The IDP initiated login implementation prefers _POST_ over _REDIRECT_ binding (check <<saml-bindings, saml bindings>> for more information).
+The IDP initiated login implementation prefers _POST_ over _REDIRECT_ binding (check <<_saml, saml bindings>> for more information).
 Therefore the final binding and SP URL are selected in the following way:
 
 1. If the specific `Assertion Consumer Service POST Binding URL` is defined (inside `Fine Grain SAML Endpoint Configuration` section

--- a/server_development/pom.xml
+++ b/server_development/pom.xml
@@ -11,7 +11,7 @@
 
     <name>Server Developer</name>
     <artifactId>server-development</artifactId>
-    <packaging>jar</packaging>
+    <packaging>pom</packaging>
 
     <build>
         <plugins>


### PR DESCRIPTION
The warnings in the log will cause all automatic builds to be in warning status instead of success.

This PR is also to try out changes to dawbrn.