### PR TITLE
KEYCLOAK-6073 Document auth-server-backchannel-url configuration.

### DIFF
--- a/securing_apps/topics/oidc/java/java-adapter-config.adoc
+++ b/securing_apps/topics/oidc/java/java-adapter-config.adoc
@@ -12,6 +12,7 @@ This is what one might look like:
   "resource" : "customer-portal",
   "realm-public-key" : "MIGfMA0GCSqGSIb3D...31LwIDAQAB",
   "auth-server-url" : "https://localhost:8443/auth",
+  "auth-server-backchannel-url" : "https://localhost:8443/auth",
   "ssl-required" : "external",
   "use-resource-role-mappings" : false,
   "enable-cors" : true,
@@ -68,6 +69,12 @@ realm-public-key::
 auth-server-url::
   The base URL of the {project_name} server. All other {project_name} pages and REST service endpoints are derived from this. It is usually of the form `$$https://host:port/auth$$`.
   This is _REQUIRED._
+
+auth-server-backchannel-url::
+  The base URL of the {project_name} server that is used for backchannel requests. All other backchannel REST service endpoints are derived from this. It is usually of the form `$$https://host:port/auth$$`.
+  Typically this will be set to an internal URL when the secured app and the {project_name} server resides in the same network.
+  When this option is used, the {project_name} server _must_ be configured to use a link:{adminguide_link}#host[fixed request provider].
+  This is _OPTIONAL._ If not set the `auth-server-url` will be used for backchannel requests.
 
 ssl-required::
   Ensures that all communication to and from the {project_name} server is over HTTPS.


### PR DESCRIPTION
Documentation for [KEYCLOAK-6073](https://issues.jboss.org/browse/KEYCLOAK-6073)