### PR TITLE
KEYCLOAK-10747 Explicit Proof Key for Code Exchange Activation Settings

### DIFF
--- a/server_admin/topics/clients/client-oidc.adoc
+++ b/server_admin/topics/clients/client-oidc.adoc
@@ -149,6 +149,21 @@ WARNING:
 None of the keycloak client adapters currently support holder-of-key token verification.
 Instead, keycloak adapters currently treat access and refresh tokens as bearer tokens.
 
+[[_proof-key-for-code-exchange]]
+*Proof Key for Code Exchange (PKCE)*
+
+When an attacker steals an authorization code that was issued to a legitimate client, PKCE prevents the attacker from receiving the tokens that apply to that code.
+
+The administrator can select the following three options:
+
+*Proof Key for Code Exchange Code Challenge Method*
+
+* (blank) : {project_name} does not apply PKCE unless the client sends PKCE's parameters appropriately to keycloak's authorization endpoint. It is the default setting.
+* S256 : {project_name} applies to the client PKCE whose code challenge method is S256.
+* plain : {project_name} applies to the client PKCE whose code challenge method is plain.
+
+Please see https://tools.ietf.org/html/rfc7636[RFC 7636 Proof Key for Code Exchange by OAuth Public Clients] for more details.
+
 
 
 

--- a/server_admin/topics/threat/compromised-codes.adoc
+++ b/server_admin/topics/threat/compromised-codes.adoc
@@ -7,3 +7,5 @@ An authorization code can only be used once to obtain an access token.
 In the admin console you can specify how long an authorization code is valid for on the <<_timeouts, timeouts page>>.
 This value should be really short, as short as a few seconds and just long enough for the client to make the request to obtain a token from the code.
 
+You can also mitigate against leaked autorization codes by applying PKCE to clients. See <<_proof-key-for-code-exchange, Proof Key for Code Exchange (PKCE)>> to learn how.
+


### PR DESCRIPTION
This is the documentation for https://github.com/keycloak/keycloak/pull/6135 .