### PR TITLE
Improve JS Adapter Documentation Admin Labels

### DIFF
--- a/securing_apps/topics/oidc/javascript-adapter.adoc
+++ b/securing_apps/topics/oidc/javascript-adapter.adoc
@@ -13,7 +13,7 @@ credentials in a client-side application. This makes it very important to make s
 To use the JavaScript adapter you must first create a client for your application in the {project_name} Administration Console. Make sure `public`
 is selected for `Access Type`.
 
-You also need to configure valid redirect URIs and valid web origins. Be as specific as possible as failing to do so may result in a security vulnerability.
+You also need to configure `Valid Redirect URIs` and `Web Origins`. Be as specific as possible as failing to do so may result in a security vulnerability.
 
 Once the client is created click on the `Installation` tab select `Keycloak OIDC JSON` for `Format Option` then click `Download`. The downloaded
 `keycloak.json` file should be hosted on your web server at the same location as your HTML pages.


### PR DESCRIPTION
The documentation currently does not use the same wording as the administrative UI. This makes finding the
correct setting more difficult. Additionally, the documentation does not surround the field names in tick
marks as it does in other places. This makes it less obvious what configuration needs to be done.

This commit adjusts the wording to match the administrative UI. It also ensures the field names are enclosed in tick marks.