### PR TITLE
KEYCLOAK-10266

### DIFF
--- a/securing_apps/topics/oidc/java/spring-security-adapter.adoc
+++ b/securing_apps/topics/oidc/java/spring-security-adapter.adoc
@@ -6,6 +6,25 @@ You then have to provide some extra beans in your Spring Security configuration 
 
 Unlike the other Keycloak Adapters, you should not configure your security in web.xml.
 However, keycloak.json is still required.
+In order for Single Sign Out work properly you have to define a session listener.
+
+.The session listener can be defined:
+* in web.xml (for pure Spring Security environments):
+[source,xml]
+---- 
+<listener>
+     <listener-class>org.springframework.security.web.session.HttpSessionEventPublisher</listener-class>
+</listener>
+----
+* as a Spring bean (in Spring Boot environments using Spring Security adapter)
+[source,java]
+----
+@Bean
+public ServletListenerRegistrationBean<HttpSessionEventPublisher> httpSessionEventPublisher() {
+    return new ServletListenerRegistrationBean<HttpSessionEventPublisher>(new HttpSessionEventPublisher());
+}
+----
+
 
 ===== Adapter Installation
 


### PR DESCRIPTION
Added documentation for need of session listener definition in web.xml for proper Single Sign Out.
It should be merged if the code fix is merged:
https://github.com/keycloak/keycloak/pull/6371