### PR TITLE
Fix typo and name Spring Initializr

### DIFF
--- a/securing_apps/topics/oidc/java/spring-boot-adapter.adoc
+++ b/securing_apps/topics/oidc/java/spring-boot-adapter.adoc
@@ -8,7 +8,7 @@ You then have to provide some extra configuration via normal Spring Boot configu
 ===== Adapter Installation
 
 The Keycloak Spring Boot adapter takes advantage of Spring Boot's autoconfiguration so all you need to do is add the Keycloak Spring Boot starter to your project.
-They Keycloak Spring Boot Starter is also directly available from the https://start.spring.io/[Spring Start Page].
+The Keycloak Spring Boot Starter is also directly available from the https://start.spring.io/[Spring Initializr Page].
 To add it manually using Maven, add the following to your dependencies:
 
 


### PR DESCRIPTION
Fixed Typo: _They_ -> _The_

Link to start.spring.io is using official "Spring Initializr" as link text now.