### PR TITLE
Add missing filters to XML configuration example

### DIFF
--- a/securing_apps/topics/oidc/java/spring-security-adapter.adoc
+++ b/securing_apps/topics/oidc/java/spring-security-adapter.adoc
@@ -136,6 +136,15 @@ While Spring Security's XML namespace simplifies configuration, customizing the 
     <bean id="keycloakAuthenticationProcessingFilter" class="org.keycloak.adapters.springsecurity.filter.KeycloakAuthenticationProcessingFilter">
         <constructor-arg name="authenticationManager" ref="authenticationManager" />
     </bean>
+    
+    <bean id="keycloakCustomFilterAfterServletApiSupportFilter" class="org.springframework.web.filter.CompositeFilter">
+        <property name="filters">
+            <list>
+                <bean id="keycloakSecurityContextRequestFilter" class="org.keycloak.adapters.springsecurity.filter.KeycloakSecurityContextRequestFilter" />
+                <bean id="keycloakAuthenticatedActionsRequestFilter" class="org.keycloak.adapters.springsecurity.filter.KeycloakAuthenticatedActionsFilter" />
+            </list>
+        </property>
+    </bean>
 
     <bean id="keycloakLogoutHandler" class="org.keycloak.adapters.springsecurity.authentication.KeycloakLogoutHandler">
         <constructor-arg ref="adapterDeploymentContext" />
@@ -160,6 +169,7 @@ While Spring Security's XML namespace simplifies configuration, customizing the 
     <security:http auto-config="false" entry-point-ref="keycloakAuthenticationEntryPoint">
         <security:custom-filter ref="keycloakPreAuthActionsFilter" before="LOGOUT_FILTER" />
         <security:custom-filter ref="keycloakAuthenticationProcessingFilter" before="FORM_LOGIN_FILTER" />
+        <security:custom-filter ref="keycloakCustomFilterAfterServletApiSupportFilter" after="SERVLET_API_SUPPORT_FILTER" />
         <security:intercept-url pattern="/customers**" access="ROLE_USER" />
         <security:intercept-url pattern="/admin**" access="ROLE_ADMIN" />
         <security:custom-filter ref="logoutFilter" position="LOGOUT_FILTER" />


### PR DESCRIPTION
Add filters that are present through the annotations but not in the XML configuration example. These filters are needed to obtain the users' authorization.