### PR TITLE
Newbie friendly: "Wildfly 11" -> "Wildfly 11+"

### DIFF
--- a/getting_started/topics/secure-jboss-app/install-client-adapter.adoc
+++ b/getting_started/topics/secure-jboss-app/install-client-adapter.adoc
@@ -60,14 +60,14 @@ $ ./jboss-cli.sh --file=adapter-install-offline.cli
 > jboss-cli.bat --file=adapter-install-offline.cli
 ----
 
-.Wildfly 11 and Linux/Unix
+.Wildfly 11+ and Linux/Unix
 [source,bash,subs=+attributes]
 ----
 $ cd bin
 $ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli
 ----
 
-.Wildfly 11 and Windows
+.Wildfly 11+ and Windows
 [source,bash,subs=+attributes]
 ----
 > cd bin


### PR DESCRIPTION
For a first-time user, I believe 11+ is less confusing. I had to search articles to make sure that 11 actually meant 11+. I thought it was possible that Wildfly 12 and above didn't require any action to install the adapter.