### PR TITLE
Update server version to 4.6.0 in known issue

### DIFF
--- a/securing_apps/topics/oidc/keycloak-gatekeeper.adoc
+++ b/securing_apps/topics/oidc/keycloak-gatekeeper.adoc
@@ -519,4 +519,4 @@ All cookies are part of the header request, so you might find a problem with the
 
 ==== Known Issues
 
-There is a known issue with the Keycloak server 4.7.0.Final in which Gatekeeper is unable to find the _client_id_ in the _aud_ claim. This is due to the fact the _client_id_ is not in the audience anymore. The workaround is to add the "Audience" protocol mapper to the client with the audience pointed to the _client_id_. For more information, see link:https://issues.redhat.com/browse/KEYCLOAK-8954[KEYCLOAK-8954].
+There is a known issue with the Keycloak server 4.6.0.Final in which Gatekeeper is unable to find the _client_id_ in the _aud_ claim. This is due to the fact the _client_id_ is not in the audience anymore. The workaround is to add the "Audience" protocol mapper to the client with the audience pointed to the _client_id_. For more information, see link:https://issues.redhat.com/browse/KEYCLOAK-8954[KEYCLOAK-8954].


### PR DESCRIPTION
* per author of KEYCLOAK-8954, Keycloak server 4.6.0 was when problem occurred.
* FYI: Keycloak gatekeeper 2.3.0 does work Keycloak server 8.0.1 without the workaround