### PR TITLE
KEYCLOAK-13082 two downloadable distributions

### DIFF
--- a/server_installation/topics/installation/distribution-files-community.adoc
+++ b/server_installation/topics/installation/distribution-files-community.adoc
@@ -1,7 +1,7 @@
 
 === Installing Distribution Files
 
-The Keycloak Server has three downloadable distributions:
+The Keycloak Server has two downloadable distributions:
 
 * 'keycloak-{project_version}.[zip|tar.gz]'
 * 'keycloak-overlay-{project_version}.[zip|tar.gz]'


### PR DESCRIPTION
Keycloak Server has two downloadable distributions, instead of three