### PR TITLE
Fix the link of Apache Felix HTTP Service

### DIFF
--- a/securing_apps/topics/oidc/java/servlet-filter-adapter.adoc
+++ b/securing_apps/topics/oidc/java/servlet-filter-adapter.adoc
@@ -156,6 +156,6 @@ public class Activator implements BundleActivator {
 }
 ----
 
-Please refer to http://felix.apache.org/documentation/subprojects/apache-felix-http-service.html#using-the-osgi-http-whiteboard[Apache Felix HTTP Service] for more info on programmatic registration.
+Please refer to https://github.com/apache/felix-dev/tree/master/http#using-the-osgi-http-whiteboard[Apache Felix HTTP Service] for more info on programmatic registration.
 
 endif::[]


### PR DESCRIPTION
This makes the Travis-CI test `checkExternalLinks(org.keycloak.documentation.test.SecuringAppsTest)` failed.