### PR TITLE
Move top-menu-version away from main content

### DIFF
--- a/aggregation/navbar-head.html
+++ b/aggregation/navbar-head.html
@@ -55,7 +55,7 @@
 
        div.top-menu-version {
            position: fixed;
-           bottom: 0;
+           top: 52px;
            left: 0;
            z-index: 9999;
        }
@@ -142,7 +142,6 @@ h1 {
 
 #toc.toc2 {
     top: 30px;
-    bottom: 50px;
     height: unset;
 }
 

--- a/aggregation/navbar-head.html
+++ b/aggregation/navbar-head.html
@@ -55,7 +55,8 @@
 
        div.top-menu-version {
            position: fixed;
-           top: 0;
+           bottom: 0;
+           left: 0;
            z-index: 9999;
        }
 
@@ -64,7 +65,14 @@
            margin: 0;
            background-color: #eee;
            height: 48px;
+           width: 20em;
            padding: 7px;
+       }
+
+       @media only screen and (max-width: 1280px) {
+              div.top-menu-version .content {
+                     width: 15em;
+              }
        }
 
        .versionarchive {
@@ -134,7 +142,7 @@ h1 {
 
 #toc.toc2 {
     top: 30px;
-    bottom: 0px;
+    bottom: 50px;
     height: unset;
 }
 

--- a/aggregation/navbar-head.html
+++ b/aggregation/navbar-head.html
@@ -161,7 +161,7 @@ body.toc2 {
 
 @media only screen and (min-width:1280px) {
     #toc.toc2 {
-        top: 48px;
+        top: 100px;
     }
 
     body.toc2 {


### PR DESCRIPTION
When reading the doc, the `top-menu-version` is hiding part of the main content, and occupying space in the area where the reader has the most focus. After a while, this becomes really annoying!

This change will move it to the bottom of the sidebar.

![Screenshot from 2020-03-27 06-52-08](https://user-images.githubusercontent.com/48388358/77720362-c66fa700-6ff8-11ea-9e29-6b90a7af0f29.png)

![Screenshot from 2020-03-27 07-06-37](https://user-images.githubusercontent.com/48388358/77720800-008d7880-6ffa-11ea-8c37-f60305f122cd.png)

