### PR TITLE
Update https.adoc

### DIFF
--- a/server_installation/topics/network/https.adoc
+++ b/server_installation/topics/network/https.adoc
@@ -8,7 +8,7 @@ This default behavior is defined by the SSL/HTTPS mode of each {project_name} re
 link:{adminguide_link}[{adminguide_name}], but let's give some context and a brief overview of these modes.
 
 external requests::
-  {project_name} can run out of the box without SSL so long as you stick to private IP addresses like `localhost`, `127.0.0.1`, `10.x.x.x`, `192.168.x.x`, and `172.16.x.x`.
+  {project_name} can run out of the box without SSL so long as you stick to private IP addresses like `localhost`, `127.0.0.1`, `10.x.x.x/8`, `192.168.x.x/16`, and `172.16.x.x/12`.
   If you don't have SSL/HTTPS configured on the server or you try to access {project_name} over HTTP from a non-private IP adress you will get an error.
 
 none::


### PR DESCRIPTION
The text says: "... can run out of the box without SSL so long as you stick to private IP addresses like` localhost`, `127.0.0.1`,` 10.xxx`, `192.168.xx`, and` 172.16.xx` ... "
If it is a private network it would not be better with IP mask, so the 172.16.x.x network would go up to 172.31.x.x, that is, 172.16.x.x / 12.
So the correction would be:
  "... can run out of the box without SSL so long as you stick to private IP addresses like` localhost`, `127.0.0.1`,` 10.xxx / 8`, `192.168.xx / 16`, and` 172.16.xx` ... / 12 "