### PR TITLE
KEYCLOAK-13950 SAML2 Identity Provider - Send Subject in SAML requests

### DIFF
--- a/server_admin/topics/identity-broker/saml.adoc
+++ b/server_admin/topics/identity-broker/saml.adoc
@@ -64,6 +64,9 @@ You must define the SAML configuration options as well.  They basically describe
 
 |Validating X509 Certificate
 |The public certificate that will be used to validate the signatures of SAML requests and responses from the external IDP.
+
+|Pass subject
+|Whether or not a `login_hint` query parameter should be forwarded to the IDP. When provided, this login_hint parameter is added to AuthnRequest's Subject. This allows destination providers to prefill their login form. When no login_hint is provided, nothing is forwarded as an AuthnRequest Subject.
 |===
 
 
@@ -98,3 +101,5 @@ http[s]://{host:port}/auth/realms/${realm-name}/broker/{broker-alias}/login
 ----
 
 Adding a query parameter named `login_hint` to this URL will add its value to SAML request as a Subject attribute. When this query parameter is absent or left empty, no subject will be added to the request.
+
+"Pass subject" option must be enabled.

--- a/server_admin/topics/identity-broker/saml.adoc
+++ b/server_admin/topics/identity-broker/saml.adoc
@@ -87,4 +87,14 @@ This metadata is also available publicly by going to the URL.
 http[s]://{host:port}/auth/realms/{realm-name}/broker/{broker-alias}/endpoint/descriptor
 ----
 
+[[_identity_broker_saml_login_hint]]
+==== Send Subject in SAML requests
 
+By default, a social button pointing to a SAML Identity Provider redirects the user to a login URL:
+
+[source]
+----
+http[s]://{host:port}/auth/realms/${realm-name}/broker/{broker-alias}/login
+----
+
+Adding a query parameter named `login_hint` to this URL will add its value to SAML request as a Subject attribute. When this query parameter is absent or left empty, no subject will be added to the request.


### PR DESCRIPTION
## Motivation

When working with SAML IDPs, it is currently not possible to send a Subject. This subject can prefill the username input field during the login process.

As mentionned by @hmlnarik in [KEYCLOAK-13858](https://issues.redhat.com/browse/KEYCLOAK-13858), the Subject is an optional standard element of SAML requests: See https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf, line 2017 and below.

## Solution

This PR takes a query parameter named `login_hint` into account and add it to the SAML Request as a Subject element. When no login_hint is provided, no Subject is added to the request.

This does not require any change in the identity provider configuration.

## Limitations

Pay attention that several IDPs do not support the Subject element of SAML. For instance: ADFS simply ignores it: https://docs.microsoft.com/en-us/azure/active-directory/develop/single-sign-on-saml-protocol#subject

## `login_hint`

Why a `login_hint` and not a `subject` query parameter? I believe Keycloak exposes its Identity Providers (SAML or not) as an OpenID facade and then redirect the requests to the appropriate providers.
Considering OpenID already has a standard `login_hint` query parameter, this makes sense to support the same contract.

## Usage

By default, a social button pointing to a SAML Identity Provider redirects the user to a login URL `http[s]://{host:port}/auth/realms/{realm-name}/broker/{broker-alias}/login?<query-parameters>`
Adding a `login_hint` query parameter to this URL will add its value to SAML request as a Subject attribute.

