### PR TITLE
link current best practice for OAuth

### DIFF
--- a/server_admin/topics/threat.adoc
+++ b/server_admin/topics/threat.adoc
@@ -3,6 +3,6 @@
 This chapter discusses possible security vulnerabilities any authentication server could have and how {project_name}
 mitigates those vulnerabilities.
 A good list of potential vulnerabilities and what security implementations should do to mitigate them can be found in
-the https://tools.ietf.org/html/rfc6819[OAuth 2.0 Threat Model] document put out by the IETF.
+the https://tools.ietf.org/html/rfc6819[OAuth 2.0 Threat Model] document and its most recent extension https://tools.ietf.org/html/draft-ietf-oauth-security-topics-15[OAuth 2.0 Security Best Current Practice] put out by the IETF.
 Many of those vulnerabilities are discussed here. 
 


### PR DESCRIPTION
It could also be considered to link the oauth.net website (https://oauth.net/2/oauth-best-practice/) instead to always point to the most recent document.