### PR TITLE
index.html change when web-context is changed

### DIFF
--- a/server_installation/topics/config-subsystem/cli-recipes.adoc
+++ b/server_installation/topics/config-subsystem/cli-recipes.adoc
@@ -18,6 +18,12 @@ For domain mode, this would mean something like:
 ----
 /subsystem=keycloak-server/:write-attribute(name=web-context,value=myContext)
 ----
+_Note: If you change the web-context, change index.html under welcome-content folder as well. For above example it will be_
+[source]
+-----
+window.location.href = "/myContext/"
+<a href='/myContext'>
+-----
 ==== Set the global default theme
 [source]
 ----


### PR DESCRIPTION
Whenever the web-context is updated we also should make a change in index.html under the welcome-content folder. If we don't do this change then the server throws 404 Not found when we hit the base URL of the server.