### PR TITLE
KEYCLOAK-9321 Add note to migration guide about removed endpoint

### DIFF
--- a/upgrading/topics/keycloak/changes.adoc
+++ b/upgrading/topics/keycloak/changes.adoc
@@ -35,6 +35,12 @@ a new account in Keycloak. This is because Instagram user IDs are not compatible
 new API temporarily returns both new and old user IDs to allow migration. Keycloak automatically migrates the ID once user
 logs in.
 
+==== Non-standard token introspection endpoint removed
+
+In previous versions, Keycloak advertized two introspection endpoints: `token_introspection_endpoint` and `introspection_endpoint`.
+The latter is the one defined by https://tools.ietf.org/html/rfc8414#section-2[RFC-8414]. The former, previously deprecated,
+has now been removed.
+
 === Migrating to 9.0.1
 
 ==== Legacy promise in JavaScript adapter


### PR DESCRIPTION
The migration guide for 11.0.0 includes a note about the non-standard
token_introspection_endpoint that has been removed.

Change made here: https://github.com/keycloak/keycloak/pull/7273