### PR TITLE
KEYCLOAK-14862 Upgrade httpclient test dependency

### DIFF
--- a/release_notes/topics/product/7_4_final.adoc
+++ b/release_notes/topics/product/7_4_final.adoc
@@ -102,7 +102,7 @@ When you go to Manage Account, you will see the new Account Console.  Here is a 
 
 image:{project_images}/device-activity.png[]
 
-This new console is based on link:https://reactjs.org/[React] and link:https://www.patternfly.org/v4/[PatternFly 4].  It allows you to use link:https://www.patternfly.org/v4/documentation/overview/global-css-variables[PatternFly CSS variables] for easy styling.  It also allows you to remove pages and add your own pages.  Full documentation will be provided at a future release.
+This new console is based on link:https://reactjs.org/[React] and link:https://www.patternfly.org/v4/[PatternFly 4].  It allows you to use link:https://www.patternfly.org/v4/documentation/overview/global-css-variables/[PatternFly CSS variables] for easy styling.  It also allows you to remove pages and add your own pages.  Full documentation will be provided at a future release.
 
 == New default hostname provider
 

--- a/securing_apps/topics/oidc/keycloak-gatekeeper.adoc
+++ b/securing_apps/topics/oidc/keycloak-gatekeeper.adoc
@@ -450,7 +450,7 @@ The proxy will automatically rotate the server certificates if the files change 
 
 If a request for an access token contains a refresh token and  `--enable-refresh-tokens` is set to `true`, the proxy will automatically refresh the access token for you. The tokens themselves are kept either as an encrypted *(--encryption-key=KEY)* cookie *(cookie name: kc-state).* or a store *(still requires encryption key)*.
 
-At present the only store options supported are link:https://github.com/antirez/redis[Redis] and link:https://github.com/boltdb/bolt[Boltdb].
+At present the only store options supported are link:https://github.com/redis/redis[Redis] and link:https://github.com/boltdb/bolt[Boltdb].
 
 To enable a local boltdb store use `--store-url boltdb:///PATH` or using a relative path `boltdb://PATH`.
 

--- a/server_admin/topics/clients/client-oidc.adoc
+++ b/server_admin/topics/clients/client-oidc.adoc
@@ -106,7 +106,7 @@ For more information see link:{adapterguide_link}[{adapterguide_name}].
 
 *Web Origins*
 
-This option centers around link:http://www.w3.org/TR/cors/[CORS] which stands for Cross-Origin Resource Sharing.
+This option centers around link:https://fetch.spec.whatwg.org/[CORS] which stands for Cross-Origin Resource Sharing.
 If browser JavaScript tries to make an AJAX HTTP request to a server whose domain is different from the one the
 JavaScript code came from, then the request must use CORS.
 The server must handle CORS requests in a special way, otherwise the browser will not display or allow the request to be processed.

--- a/server_admin/topics/identity-broker/social/bitbucket.adoc
+++ b/server_admin/topics/identity-broker/social/bitbucket.adoc
@@ -13,7 +13,7 @@ NOTE: You will use the `Redirect URI` from this page in a later step, which you 
 
 .Add a New App
 To enable login with Bitbucket you must first register an application project in
-https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html[OAuth on Bitbucket Cloud].
+https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/[OAuth on Bitbucket Cloud].
 
 NOTE: Bitbucket often changes the look and feel of application registration, so what you see on the Bitbucket site may differ. If in doubt, see the Bitbucket documentation.
 

--- a/server_development/topics/extensions.adoc
+++ b/server_development/topics/extensions.adoc
@@ -134,7 +134,7 @@ EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityMan
 Company myCompany = em.find(Company.class, "123");
 ----
 
-The methods `getChangelogLocation` and `getFactoryId` are important to support automatic updating of your entities by Liquibase. http://www.liquibase.org/[Liquibase]
+The methods `getChangelogLocation` and `getFactoryId` are important to support automatic updating of your entities by Liquibase. https://www.liquibase.org/[Liquibase]
 is a framework for updating the database schema, which {project_name} internally uses to create the DB schema and update the DB schema among versions. You may need to use
 it as well and create a changelog for your entities. Note that versioning of your own Liquibase changelog is independent
 of {project_name} versions. In other words, when you update to a new {project_name} version, you are not forced to update your

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -119,9 +119,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.12</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tests/src/test/java/org/keycloak/documentation/test/utils/Constants.java
+++ b/tests/src/test/java/org/keycloak/documentation/test/utils/Constants.java
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 public class Constants {
 
-    public static final int HTTP_RETRY = 3;
+    public static final int HTTP_RETRY = 5;
     public static final int HTTP_CONNECTION_TIMEOUT = 30000;
     public static final int HTTP_READ_TIMEOUT = 300000;
     public static final long LINK_CHECK_EXPIRATION = TimeUnit.DAYS.toMillis(1);


### PR DESCRIPTION
The new version of httpclient supports handling HTTP 429 errors. This should
resolve the sporadic failures in the ReleaseNotesTest in PRs.

I also increased the retry count to 5, to make sure the default backoff
algorithm in httpclient has room to work effectively.