### PR TITLE
Update for https.adoc

### DIFF
--- a/server_installation/topics/network/https.adoc
+++ b/server_installation/topics/network/https.adoc
@@ -165,7 +165,7 @@ The resulting element, `server name="default-server"`, which is a child element 
 
 [source,xml,subs="attributes+"]
 ----
-<subsystem xmlns="{subsystem_undertow_xml_urn}">
+<subsystem xmlns="urn:jboss:domain:undertow:11.0">
    <buffer-cache name="default"/>
    <server name="default-server">
       <https-listener name="https" socket-binding="https" security-realm="UndertowRealm"/>


### PR DESCRIPTION
The current value of {subsystem_undertow_xml_urn} in the standalone-ha.xml and standalone.xml is "urn:jboss:domain:undertow:11.0" when keycloak-11.0.0 is deployed. Please could you update accordingly. I assume the value is dynamically generated