### PR TITLE
KEYCLOAK-14887 Outgoing HTTPS request truststore documentation reads …

### DIFF
--- a/server_installation/topics/network/outgoing.adoc
+++ b/server_installation/topics/network/outgoing.adoc
@@ -169,7 +169,7 @@ You can add your truststore configuration by using the following template:
             <property name="file" value="path to your .jks file containing public certificates"/>
             <property name="password" value="password"/>
             <property name="hostname-verification-policy" value="WILDCARD"/>
-            <property name="disabled" value="false"/>
+            <property name="enabled" value="true"/>
         </properties>
     </provider>
 </spi>
@@ -184,11 +184,11 @@ file::
   This is what the trustore does.
   The keystore contains one or more trusted host certificates or certificate authorities.
   This truststore file should only contain public certificates of your secured hosts.
-  This is _REQUIRED_ if `disabled` is not true.
+  This is _REQUIRED_ if `enabled` is true.
 
 password::
   Password for the truststore.
-  This is _REQUIRED_ if `disabled` is not true.
+  This is _REQUIRED_ if `enabled` is true.
 
 hostname-verification-policy::
   `WILDCARD` by default.
@@ -196,7 +196,7 @@ hostname-verification-policy::
    `ANY` means that the hostname is not verified. `WILDCARD` Allows wildcards in subdomain names i.e.
   *.foo.com. `STRICT` CN must match hostname exactly.
 
-disabled::
-  If true (default value), truststore configuration will be ignored, and certificate checking will fall back to JSSE configuration as described.
-  If set to false, you must configure `file`, and `password` for the truststore.
+enabled::
+  If false (default value), truststore configuration will be ignored, and certificate checking will fall back to JSSE configuration as described.
+  If set to true, you must configure `file`, and `password` for the truststore.
 


### PR DESCRIPTION
…'disabled' but actual parameter is 'enabled'