### PR TITLE
Update auth-spi.adoc

### DIFF
--- a/server_development/topics/auth-spi.adoc
+++ b/server_development/topics/auth-spi.adoc
@@ -518,7 +518,7 @@ Here is the implementation of the setRequiredActions() method.
 ----
     @Override
     public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
-        user.addRequiredAction("SECRET_QUESTION_CONFIG");
+        user.addRequiredAction("secret_question_config");
     }
 ----
 


### PR DESCRIPTION
The secret question required action id is written in lowercase in the example on GitHub, this is confusing for new users as the full code will give a WARN once completed.