### PR TITLE
[KEYCLOAK-13207] [KEYCLOAK-14489] [KEYCLOAK-14681] Use correct OpenShift image stream names for RH-SSO 7.4 for OpenShift on OpenJDK / OpenJ9 images

### DIFF
--- a/openshift-openj9/master.adoc
+++ b/openshift-openj9/master.adoc
@@ -8,7 +8,8 @@ include::topics/templates/document-attributes-product.adoc[]
 :project_templates_version: {openshift_openj9_project_templates_version}
 :openshift_name: {openshift_openj9_name}
 :openshift_link: {openshift_openj9_link}
-:openshift_image: {openshift_openj9_image}
+:openshift_image_repository: {openshift_openj9_image_repository}
+:openshift_image_stream: {openshift_openj9_image_stream}
 :openshift_image_platforms: {openshift_openj9_platforms}
 :openshift_name_other: {openshift_openjdk_name}
 :openshift_link_other: {openshift_openjdk_link}

--- a/openshift/master.adoc
+++ b/openshift/master.adoc
@@ -9,7 +9,8 @@ include::topics/templates/document-attributes-product.adoc[]
 :openshift_name: {openshift_openjdk_name}
 :openshift_link: {openshift_openjdk_link}
 :openshift_image_platforms: {openshift_openjdk_platforms}
-:openshift_image: {openshift_openjdk_image}
+:openshift_image_repository: {openshift_openjdk_image_repository}
+:openshift_image_stream: {openshift_openjdk_image_stream}
 :openshift_name_other: {openshift_openj9_name}
 :openshift_link_other: {openshift_openj9_link}
 

--- a/openshift/topics/advanced_concepts.adoc
+++ b/openshift/topics/advanced_concepts.adoc
@@ -312,7 +312,7 @@ as an example. Update the example for other database drivers accordingly.
 +
 [source,subs="attributes+,macros+,+quotes"]
 ----
-*FROM* {openshift_image}:latest
+*FROM* {openshift_image_repository}:latest
 
 *COPY* sso-extensions.cli /opt/eap/extensions/
 *COPY* mariadb-java-client-2.5.4.jar /opt/eap/extensions/jdbc-driver.jar

--- a/openshift/topics/get_started.adoc
+++ b/openshift/topics/get_started.adoc
@@ -57,7 +57,7 @@ done
 +
 [source,bash,subs="attributes+,macros+"]
 ----
-$ oc -n openshift import-image redhat-{project_templates_version}-openshift:{project_latest_image_tag}
+$ oc -n openshift import-image {openshift_image_repository}:{project_latest_image_tag} --from=registry.redhat.io/{openshift_image_repository}:{project_latest_image_tag} --confirm
 ----
 
 [[Example-Deploying-SSO]]

--- a/openshift/topics/reference.adoc
+++ b/openshift/topics/reference.adoc
@@ -82,24 +82,16 @@ information about the image and should not be modified by the user:
 |*_true_*
 
 |*_JBOSS_IMAGE_NAME_*
-|Image name, same as Name label.
-|*_redhat-sso-7/sso72-openshift_*
-
-|*_JBOSS_IMAGE_RELEASE_*
-|Image release, same as Release label.
-|*_dev_*
+|Image name, same as "name" label.
+|*_{openshift_image_repository}_*
 
 |*_JBOSS_IMAGE_VERSION_*
-|Image version, same as Version label.
-|*_1.1_*
+|Image version, same as "version" label.
+|*_{project_versionDoc}_*
 
 |*_JBOSS_MODULES_SYSTEM_PKGS_*
 |-
 |*_org.jboss.logmanager,jdk.nashorn.api_*
-
-|*_STI_BUILDER_*
-|Provides OpenShift S2I support for jee project types.
-|*_jee_*
 
 |===
 

--- a/openshift/topics/tutorials.adoc
+++ b/openshift/topics/tutorials.adoc
@@ -46,7 +46,7 @@ deploymentconfig "sso" scaled
 +
 [source,bash,subs="attributes+,macros+"]
 ----
-$ oc patch dc/sso --type=json -p '[{"op": "replace", "path": "/spec/triggers/0/imageChangeParams/from/name", "value": "redhat-{project_templates_version}-openshift:{project_latest_image_tag}"}]'
+$ oc patch dc/sso --type=json -p '[{"op": "replace", "path": "/spec/triggers/0/imageChangeParams/from/name", "value": "{openshift_image_stream}:{project_latest_image_tag}"}]'
 "sso" patched
 ----
 . Start rollout of the new {project_name} {project_version} images based on the latest image defined in the image change triggers.
@@ -313,15 +313,15 @@ Successfully updated TX_DATABASE_PREFIX_MAPPING to:         sso-postgresql=DB
 [source,bash,subs="attributes+,macros+"]
 ----
 $ oc get is -n openshift | grep {project_templates_version} | cut -d ' ' -f1
-redhat-{project_templates_version}-openshift
+{openshift_image_stream}
 ----
 +
 [source,bash,subs="attributes+,macros+"]
 ----
-$ oc new-build redhat-{project_templates_version}-openshift:{project_latest_image_tag}~https://github.com/iankko/openshift-examples.git#KEYCLOAK-8500 \
+$ oc new-build {openshift_image_stream}:{project_latest_image_tag}~https://github.com/iankko/openshift-examples.git#KEYCLOAK-8500 \
   --context-dir=sso-manual-db-migration \
   --name={project_templates_version}-db-migration-image
---> Found image bf45ac2 (7 days old) in image stream "openshift/redhat-{project_templates_version}-openshift" under tag "{project_latest_image_tag}" for "redhat-{project_templates_version}-openshift:{project_latest_image_tag}"
+--> Found image bf45ac2 (7 days old) in image stream "openshift/{openshift_image_stream}" under tag "{project_latest_image_tag}" for "{openshift_image_stream}:{project_latest_image_tag}"
 
     Red Hat SSO {project_version}
     ---------------
@@ -476,7 +476,7 @@ Replace `<PREFIX>_USERNAME` and `<PREFIX>_DATABASE` with the actual database cre
 +
 [source,bash,subs="attributes+,macros+"]
 ----
-$ oc patch dc/sso --type=json -p '[{"op": "replace", "path": "/spec/triggers/0/imageChangeParams/from/name", "value": "redhat-{project_templates_version}-openshift:{project_latest_image_tag}"}]'
+$ oc patch dc/sso --type=json -p '[{"op": "replace", "path": "/spec/triggers/0/imageChangeParams/from/name", "value": "{openshift_image_stream}:{project_latest_image_tag}"}]'
 "sso" patched
 ----
 . Start rollout of the new {project_name} {project_version} images based on the latest image defined in the image change triggers.

--- a/tests/src/test/resources/ignored-links
+++ b/tests/src/test/resources/ignored-links
@@ -30,6 +30,8 @@ http://127.0.0.1:3000/oauth/callback
 https://api.linkedin.com/v2/me
 https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/templates/${resource}
 https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso73-dev/templates/${resource}
+https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso74-dev/templates/${resource}
+https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso74-dev/templates/openj9/${resource}
 https://issues.redhat.com/secure/CreateIssueDetails*
 https://developer.paypal.com/developer/applications
 https://account.live.com/developers/applications/create

--- a/topics/templates/document-attributes-product.adoc
+++ b/topics/templates/document-attributes-product.adoc
@@ -11,7 +11,7 @@
 :keycloak_upgrade_version: 9.0.x
 :project_versionDoc: 7.4
 :project_templates_base_url: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso74-dev/templates
-:project_latest_image_tag: 1.0
+:project_latest_image_tag: {project_versionDoc}
 :project_doc_base_url: https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{project_versionDoc}/html-single
 :maven_repository: https://maven.repository.redhat.com/ga/
 
@@ -63,15 +63,18 @@
 :upgradingguide_link: {project_doc_base_url}/upgrading_guide/
 :releasenotes_name: Release Notes
 :releasenotes_link: {project_doc_base_url}/release_notes/
+:openshift_image_repository_productline: rh-sso-7
 :openshift_openjdk_name: Red Hat Single Sign-On for OpenShift on OpenJDK
 :openshift_openjdk_link: {project_doc_base_url}/red_hat_single_sign-on_for_openshift/
 :openshift_openjdk_platforms: x86_64
-:openshift_openjdk_image: redhat-sso-7/sso74-openshift-rhel8
+:openshift_openjdk_image_stream: sso74-openshift-rhel8
+:openshift_openjdk_image_repository: {openshift_image_repository_productline}/{openshift_openjdk_image_stream}
 :openshift_openjdk_project_templates_version: sso74
 :openshift_openj9_name: Red Hat Single Sign-On for OpenShift on Eclipse OpenJ9
 :openshift_openj9_link: {project_doc_base_url}/red_hat_single_sign-on_for_openshift_on_openj9/
 :openshift_openj9_platforms: IBM Z/IBM Power Systems
-:openshift_openj9_image: redhat-sso-7/sso74-openj9-openshift-rhel8
+:openshift_openj9_image_stream: sso74-openj9-openshift-rhel8
+:openshift_openj9_image_repository: {openshift_image_repository_productline}/{openshift_openj9_image_stream}
 :openshift_openj9_project_templates_version: sso74-openj9
 
 // Aggregate various frequently referred links to the official OCP documentation


### PR DESCRIPTION
Update / use correct image stream names for RH-SSO 7.4 for OpenShift on OpenJDK / OpenJ9 image in various sections of the documentation so:

- [KEYCLOAK-13207] The `JBOSS_IMAGE_NAME` variable is automatically derived from the image stream name (instead of containing a hardcoded / fixed value like in the current form),
- [KEYCLOAK-14489] The section describing on how to perform image import into OpenShift starts working again,
- [KEYCLOAK-14681] The section describing on how to perform automatic and manual database migration starts working again

_Note:_ The changes related to a particular JIRA are intentionally left in separate commit(s), so it's immediately visible what got fixed.