### PR TITLE
KEYCLOAK-14979 Fix out of level sequence section title in Keycloak changes

### DIFF
--- a/upgrading/topics/keycloak/changes.adoc
+++ b/upgrading/topics/keycloak/changes.adoc
@@ -88,7 +88,7 @@ KEYCLOAK-12579-add-not-null-constraint::keycloak failed.`
 
 === Migrating to 9.0.0
 
-===== Improved handling of user locale
+==== Improved handling of user locale
 
 A number of improvements have been made to how the locale for the login page is selected, as well as when the locale
 is updated for a user.


### PR DESCRIPTION
This should clear the warning that the docs bot has been reporting for a long
time:

```
asciidoctor: WARNING: topics/keycloak/changes.adoc: line 96: section title out of sequence: expected level 3, got level 4
```