### PR TITLE
KEYCLOAK-15079 Resolve four test failures

### DIFF
--- a/getting_started/index.adoc
+++ b/getting_started/index.adoc
@@ -2,6 +2,7 @@
 :toclevels: 3
 :sectanchors:
 :linkattrs:
+:context:
 
 include::topics/templates/document-attributes-community.adoc[]
 

--- a/getting_started/topics/assembly-installing-standalone.adoc
+++ b/getting_started/topics/assembly-installing-standalone.adoc
@@ -15,7 +15,7 @@ This section describes how to install and start a {project_name} server in stand
 
 ifeval::[{project_product}==true]
 .Additional Resources
-This installation is intended for practice use of {project_name}. For instructions on installation in a production environment and full details on all product features, see the other guides in the link:http://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{project_versionDoc}/[{project_name}] documentation.
+This installation is intended for practice use of {project_name}. For instructions on installation in a production environment and full details on all product features, see the other guides in the link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{project_versionDoc}/[{project_name}] documentation.
 endif::[]
 
 ifeval::[{project_community}==true]

--- a/securing_apps/topics/oidc/java/fuse7-adapter.adoc
+++ b/securing_apps/topics/oidc/java/fuse7-adapter.adoc
@@ -11,7 +11,7 @@ endif::[]
 ifeval::[{project_product}==true]
 <<_jboss_adapter,JBoss EAP 7 Adapter>>
 endif::[]
-as {fuse7Version} is bundled with http://undertow.io/[Undertow HTTP engine] under the covers and Undertow is used for running various kinds of web applications.
+as {fuse7Version} is bundled with https://undertow.io/[Undertow HTTP engine] under the covers and Undertow is used for running various kinds of web applications.
 
 WARNING: The only supported version of Fuse 7 is the latest release. If you use earlier versions of Fuse 7, it is possible that some functions will not work correctly. In particular, integration will not work at all for versions of Fuse 7 lower than 7.0.1.
 

--- a/topics/templates/document-attributes-product.adoc
+++ b/topics/templates/document-attributes-product.adoc
@@ -9,7 +9,7 @@
 :project_version_base: 7.4
 :project_version: 7.4.1
 :keycloak_upgrade_version: 9.0.x
-:project_versionDoc: 7.4.1
+:project_versionDoc: 7.4
 :project_templates_base_url: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso74-dev/templates
 :project_latest_image_tag: 1.0
 :project_doc_base_url: https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{project_versionDoc}/html-single


### PR DESCRIPTION
This PR resolves these test failures, currently on master:

```
Tests run: 5, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 38.833 sec <<< FAILURE!
checkExternalLinks(org.keycloak.documentation.test.SecuringAppsTest)  Time elapsed: 38.723 sec  <<< FAILURE!
* http://undertow.io/ (invalid redirect to https://undertow.io/)

Tests run: 5, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.999 sec <<< FAILURE!
checkVariables(org.keycloak.documentation.test.GettingStartedTest)  Time elapsed: 0.004 sec  <<< FAILURE!
* context

Running org.keycloak.documentation.test.ServerInstallationTest
```

And these product test failures:

```
Running org.keycloak.documentation.test.GettingStartedTest
Tests run: 5, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.79 sec <<< FAILURE!
checkExternalLinks(org.keycloak.documentation.test.GettingStartedTest)  Time elapsed: 0.767 sec  <<< FAILURE!
* http://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4.1/ (invalid redirect to https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4.1/)

Running org.keycloak.documentation.test.OpenShiftTest
Tests run: 5, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 8.502 sec <<< FAILURE!
checkExternalLinks(org.keycloak.documentation.test.OpenShiftTest)  Time elapsed: 8.404 sec  <<< FAILURE!
* https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4.1/html-single/red_hat_single_sign-on_for_openshift_on_openj9/ (invalid status code 404)
```