### PR TITLE
[KEYCLOAK-2940] Documentation for backchannel logout

### DIFF
--- a/server_admin/topics/clients/client-oidc.adoc
+++ b/server_admin/topics/clients/client-oidc.adoc
@@ -121,6 +121,25 @@ See link:{adapterguide_link}[{adapterguide_name}] for more information.
 To fill in the `Web Origins` data, enter in a base URL and click the + sign to add.  Click the - sign next to URLs you want to remove.
 Remember that you still have to click the `Save` button!
 
+*Backchannel Logout URL*
+
+When {project_name} receives a logout request via `end_session_endpoint` it will post a backchannel logout request at this URL like described in the
+https://openid.net/specs/openid-connect-backchannel-1_0.html[OpenID Connect specification].
+This causes the client to log itself out.
+
+*Backchannel Logout Session Required*
+
+If enabled, the session id is included in the logout token when a backchannel logout request is sent.
+This results in only logging out a specific session. If disabled, all sessions of the corresponding
+user will be logged out.
+
+*Backchannel Logout Revoke Offline Sessions*
+
+If enabled, a `revoke_offline_access` event is added to the logout token. This should result in also logging out offline
+sessions with a backchannel logout request. This event is not specified by the https://openid.net/specs/openid-connect-backchannel-1_0.html[OpenID Connect specification]
+and may have to change in the future. Keycloak itself will respect the `revoke_offline_access` in a logout token when receiving
+a backchannel logout request.
+
 ==== Advanced Settings
 
 [[_mtls-client-certificate-bound-tokens]]

--- a/server_admin/topics/sso-protocols/oidc.adoc
+++ b/server_admin/topics/sso-protocols/oidc.adoc
@@ -89,6 +89,35 @@ This is also used by REST clients, but instead of obtaining a token that works o
 of an external user, a token is created based on the metadata and permissions of a service account that is associated with the client.
 More info together with example is in <<_service_accounts,Service Accounts>> chapter.
 
+[[_oidc-logout]]
+
+==== OIDC Logout
+
+OIDC has three different specifications relevant to logout mechanisms, all of these are currently in draft status:
+
+. https://openid.net/specs/openid-connect-session-1_0.html[Session Management]
+. https://openid.net/specs/openid-connect-frontchannel-1_0.html[Front-Channel Logout]
+. https://openid.net/specs/openid-connect-backchannel-1_0.html[Back-Channel Logout]
+
+Again since all of this is described in the OIDC specification we will only give a brief overview here.
+
+===== Session Management
+
+This is a browser-based logout. The application obtains session status information from {project_name} at a regular basis.
+When the session is terminated at {project_name} the application will notice and trigger it's own logout.
+
+===== Frontchannel Logout
+
+This is also a browser-based logout. In contrast to the Session Managment based logout approach {project_name} will send logout
+requests to the clients. Applications or clients need to have a frontchannel logout URL registered at {project_name}.
+After triggering a logout at {project_name}, it will send logout requests to these registered URLs that will terminate the client sessions.
+
+===== Backchannel Logout
+
+This is a non browser-based logout that uses direct backchannel communication between {project_name} and clients. 
+{project_name} sends a HTTP POST request containing a logout token to all clients logged into {project_name}. These
+requests are sent to a registered backchannel logout URLs at {project_name} and are supposed to trigger a logout at client side.
+
 ====  {project_name} Server OIDC URI Endpoints
 
 Here's a list of OIDC endpoints that the {project_name} publishes.  These URLs are useful if you are using a non-{project_name} client adapter to

--- a/server_admin/topics/sso-protocols/oidc.adoc
+++ b/server_admin/topics/sso-protocols/oidc.adoc
@@ -106,5 +106,7 @@ _/auth_:  i.e. $$https://localhost:8080/auth$$
   This is the URL endpoint for the User Info service described in the OIDC specification.
 /realms/{realm-name}/protocol/openid-connect/revoke::
   This is the URL endpoint for OAuth 2.0 Token Revocation described in https://tools.ietf.org/html/rfc7009[RFC7009].
+/realms/{realm-name}/protocol/openid-connect/logout/backchannel-logout::
+  This is the URL endpoint for performing backchannel logouts described in the OIDC specification.
 
 In all of these replace _{realm-name}_ with the name of the realm.


### PR DESCRIPTION
This PR provides the documentation related to the oidc backchannel logout. 

It refers to the following PRs in the Keycloak repository:
* https://github.com/keycloak/keycloak/pull/7272
* https://github.com/keycloak/keycloak/pull/7333

Like @pedroigor already suggested we should maybe also extend the documentation https://www.keycloak.org/docs/latest/server_admin/index.html#_oidc and add a logout section there.