### PR TITLE
Fix typo

### DIFF
--- a/authorization_services/topics/service-authorization-obtaining-permission-authentication.adoc
+++ b/authorization_services/topics/service-authorization-obtaining-permission-authentication.adoc
@@ -24,7 +24,7 @@ the resources and scopes to which User A has access.
 
 * *Client Credentials*
 +
-Client can use any of the client authentication methods supported by {project_name}. For instance, client_id/client_secret or JWT.
+Clients can use any of the client authentication methods supported by {project_name}. For instance, client_id/client_secret or JWT.
 +
 .Example: an authorization request using client id and client secret to authenticate to the token endpoint
 ```bash


### PR DESCRIPTION
The word “client” in this section wasn’t plural like in the other sections.