### PR TITLE
KEYCLOAK-15428 Fix two broken links causing test failures

### DIFF
--- a/getting_started/topics/sample-app/proc-adjusting-ports.adoc
+++ b/getting_started/topics/sample-app/proc-adjusting-ports.adoc
@@ -15,7 +15,7 @@ To avoid port conflicts, you need different ports to run {project_name} and {app
 .Procedure
 
 ifeval::[{project_community}==true]
-. Download WildFly from link:https://wildfly.org[WildFly.org].
+. Download WildFly from link:https://www.wildfly.org/[WildFly.org].
 endif::[]
 ifeval::[{project_product}==true]
 . Download JBoss EAP 7.3 from the https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=appplatform&downloadType=distributions[Red Hat customer portal].

--- a/securing_apps/topics/oidc/keycloak-gatekeeper.adoc
+++ b/securing_apps/topics/oidc/keycloak-gatekeeper.adoc
@@ -513,7 +513,7 @@ Assuming `--enable-metrics` has been set, a Prometheus endpoint can be found on 
 
 ==== Limitations
 
-Keep in mind link:http://browsercookielimits.squawky.net/[browser cookie limits] if you use access or refresh tokens in the browser cookie. Keycloak-generic-adapter divides the cookie automatically if your cookie is longer than 4093 bytes. Real size of the cookie depends on the content of the issued access token. Also, encryption might add additional bytes to the cookie size. If you have large cookies (>200 KB), you might reach browser cookie limits.
+Keep in mind browser cookie limits if you use access or refresh tokens in the browser cookie. Keycloak-generic-adapter divides the cookie automatically if your cookie is longer than 4093 bytes. Real size of the cookie depends on the content of the issued access token. Also, encryption might add additional bytes to the cookie size. If you have large cookies (>200 KB), you might reach browser cookie limits.
 
 All cookies are part of the header request, so you might find a problem with the max headers size limits in your infrastructure (some load balancers have very low this value, such as 8 KB). Be sure that all network devices have sufficient header size limits. Otherwise, your users won't be able to obtain an access token.
 


### PR DESCRIPTION
http://browsercookielimits.squawky.net no longer exists, and I can't find an
equivalent of what it did, so I've removed it.

https://wildfly.org needed a slash on the end and a www up front, to prevent a redirect.

That should resolve the test failures currently causing all PRs to be flagged.