### PR TITLE
KEYCLOAK-15158 adjust basic example of Keycloak JS adapter usage

### DIFF
--- a/securing_apps/topics/oidc/javascript-adapter.adoc
+++ b/securing_apps/topics/oidc/javascript-adapter.adoc
@@ -24,17 +24,24 @@ The following example shows how to initialize the JavaScript adapter:
 
 [source,html]
 ----
+<html>
 <head>
     <script src="keycloak.js"></script>
     <script>
-        var keycloak = new Keycloak();
-        keycloak.init().then(function(authenticated) {
-            alert(authenticated ? 'authenticated' : 'not authenticated');
-        }).catch(function() {
-            alert('failed to initialize');
-        });
+        function initKeycloak() {
+            var keycloak = new Keycloak();
+            keycloak.init().then(function(authenticated) {
+                alert(authenticated ? 'authenticated' : 'not authenticated');
+            }).catch(function() {
+                alert('failed to initialize');
+            });
+        }
     </script>
 </head>
+<body onload="initKeycloak()">
+    <!-- your page content goes here -->
+</body>
+</html>
 ----
 
 If the `keycloak.json` file is in a different location you can specify it:


### PR DESCRIPTION
As the JS adapter has evolved, it now tries to add an iframe element to the document body during initialization.
When used like in the basic example as before, there will be an JS error, as the document body is not yet available.
So we've to wait until the document is loaded, thus the initialization is put in a function and the function will be called upon body.onload()