### PR TITLE
KEYCLOAK-16072 add mising Advanced Login Configuration documentation

### DIFF
--- a/securing_apps/topics/oidc/nodejs-adapter.adoc
+++ b/securing_apps/topics/oidc/nodejs-adapter.adoc
@@ -266,6 +266,22 @@ for each section:
     app.get( '/:section/:page', keycloak.protect( protectBySection ), sectionHandler );
 ----
 
+Advanced Login Configuration:
+
+By default, all unauthorized requests will be redirected to the {project_name} login page unless your client is bearer-only. 
+However, a confidential or public client may host both browsable and API endpoints. To prevent redirects on unauthenticated 
+API requests and instead return an HTTP 401, you can override the redirectToLogin function.
+
+For example, this override checks if the URL contains /api/ and disables login redirects:
+
+[source,javascript]
+----
+    Keycloak.prototype.redirectToLogin = function(req) {
+    var apiReqMatcher = /\/api\//i;
+    return !apiReqMatcher.test(req.originalUrl || req.url);
+    };
+----
+
 ==== Additional URLs
 
 Explicit user-triggered logout::


### PR DESCRIPTION
Add missing sections in docs for `Keycloak.prototype.redirectToLogin`