### PR TITLE
KEYCLOAK-16456 X509 Auth: add option for OCSP fail-open behavior

### DIFF
--- a/server_admin/topics/authentication/x509.adoc
+++ b/server_admin/topics/authentication/x509.adoc
@@ -223,6 +223,9 @@ The path to a file containing a CRL list. The value must be a path to a valid fi
 *OCSP Checking Enabled*::
 Checks the certificate revocation status by using Online Certificate Status Protocol.
 
+*OCSP Fail-Open Behavior*::
+By default the OCSP check must return a positive response in order to continue with a successful authentication. Sometimes however this check can be inconclusive: for example, the OCSP server could be unreachable, overloaded, or the client certificate may not contain an OCSP responder URI. When this setting is turned ON, authentication will be denied only if an explicit negative response is received by the OCSP responder and the certificate is definitely revoked. If a valid OCSP response is not avalaible the authentication attempt will be accepted.
+
 *OCSP Responder URI*::
 Override the value of the OCSP responder URI in the certificate.
 


### PR DESCRIPTION
Documentation pull request for https://github.com/keycloak/keycloak/pull/7639 .