### PR TITLE
Replace wrong claim_token_format with the correct one

### DIFF
--- a/authorization_services/topics/service-authorization-obtaining-permission.adoc
+++ b/authorization_services/topics/service-authorization-obtaining-permission.adoc
@@ -23,8 +23,8 @@ permissions for the resource(s) and scope(s) being requested. This parameter all
 * **claim_token_format**
 +
 This parameter is *optional*. A string indicating the format of the token specified in the `claim_token` parameter. {project_name} supports two token
-formats: `urn:ietf:params:oauth:token-type:jwt` and `https://openid.net/specs/openid-connect-core-1_0.html#IDToken`. The `urn:ietf:params:oauth:token-type:jwt` format
-indicates that the `claim_token` parameter references an access token. The `https://openid.net/specs/openid-connect-core-1_0.html#IDToken` indicates that the
+formats: `urn:ietf:params:oauth:token-type:jwt` and `http://openid.net/specs/openid-connect-core-1_0.html#IDToken`. The `urn:ietf:params:oauth:token-type:jwt` format
+indicates that the `claim_token` parameter references an access token. The `http://openid.net/specs/openid-connect-core-1_0.html#IDToken` indicates that the
 `claim_token` parameter references an OpenID Connect ID Token.
 +
 * **rpt**


### PR DESCRIPTION
In the main documentation, `claim_token_format` for id_token is `https://openid.net/specs/openid-connect-core-1_0.html#IDToken`, which is wrong, the correct format is `http://openid.net/specs/openid-connect-core-1_0.html#IDToken` (not `https` but `http`)
You can see it for yourself here:
https://github.com/keycloak/keycloak/blob/f6be378ecae926c8ec0a5d2521e5021a06eb33da/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java#L102