### PR TITLE
Prevent leaks with SessionRegistryImpl

### DIFF
--- a/securing_apps/topics/oidc/java/spring-security-adapter.adoc
+++ b/securing_apps/topics/oidc/java/spring-security-adapter.adoc
@@ -55,9 +55,27 @@ While its use is not required, it greatly simplifies your security context confi
 ----
 
 
+@Configuration
+public class SessionConfig
+{
+    /**
+    * Defines the session registry as a bean.
+    */
+    @Bean
+    public SessionRegistry sessionRegistry() {
+        return new SessionRegistryImpl();
+    }
+}
+
 @KeycloakConfiguration
 public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter
 {
+    /**
+    * Injects the session registry bean.
+    */
+    @Autowired
+    private SessionRegistry sessionRegistry;
+    
     /**
      * Registers the KeycloakAuthenticationProvider with the authentication manager.
      */
@@ -72,7 +90,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter
     @Bean
     @Override
     protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
-        return new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl());
+        return new RegisterSessionAuthenticationStrategy(sessionRegistry);
     }
 
     @Override
@@ -89,6 +107,8 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter
 ----
 
 You must provide a session authentication strategy bean which should be of type `RegisterSessionAuthenticationStrategy` for public or confidential applications and `NullAuthenticatedSessionStrategy` for bearer-only applications.
+
+TIP: The `SessionRegistryImpl` must be registered as bean in Spring ApplicationContext, it's required to handle properly the `SessionDestroyedEvent` and prevent leaks of `SessionInformation`.
 
 Spring Security's `SessionFixationProtectionStrategy` is currently not supported because it changes the session identifier after login via Keycloak.
 If the session identifier changes, universal log out will not work because Keycloak is unaware of the new session identifier.


### PR DESCRIPTION
In the way that the definition of sessionAuthenticationStrategy is documented, SessionRegistryImpl is not reciving the sessionDestroyedEvent and is not deleting SessionInformation related to the closed session. If your aplicatión is runing long time or with hight concurrency, it would produce a fast memory leak.

SessionRegistryImpl implements ApplicationListener<SessionDestroyedEvent>, it's must be  registered with a Spring ApplicationContext as a bean to properly recieve the session destroyed event and remove the SessionInformation. Otherwise the listener will not work, never will be invoked and SessionInformation will stay in memory until the application runs.