### PR TITLE
KEYCLOAK-16945 Adding standard text about metering

### DIFF
--- a/release_notes/topics/product/7_4_final.adoc
+++ b/release_notes/topics/product/7_4_final.adoc
@@ -156,6 +156,8 @@ Two features have a change in status:
 
 * Upload of scripts through admin rest endpoints/console is deprecated. It will be removed at a future release.
 
+include::https://github.com/redhat-documentation/mw-shared-modules/blob/master/modules/ref_runtimes_metering_labels.adoc[]
+
 = Fixed Issues
 
 More than 1100 issues were fixed during this release. For details on the fixed issues, see link:https://issues.redhat.com/browse/KEYCLOAK-13785?filter=12346377[https://issues.redhat.com/issues/?filter=12346377].

--- a/topics/templates/document-attributes-product.adoc
+++ b/topics/templates/document-attributes-product.adoc
@@ -4,7 +4,8 @@
 :project_versionMvn: 9.0.3.redhat-00002
 :project_versionNpm: 9.0.3.redhat-00002
 :project_images: rhsso-images
-
+:component-name: "SSO"
+:component-version: 7.4.5
 :project_name_full: Red Hat Single Sign-On
 :project_version_base: 7.4
 :project_version: 7.4.1


### PR DESCRIPTION
dnaro@redhat.com I know this is not what is needed, but it's easier to see where I have made changes.  The main questions is how do include the new content.   This does not work:

include::https://github.com/redhat-documentation/mw-shared-modules/blob/master/modules/ref_runtimes_metering_labels.adoc[]