### PR TITLE
Fix typo: wrong possessive adjective used for Alice

### DIFF
--- a/authorization_services/topics/service-authorization-obtaining-permission-uma.adoc
+++ b/authorization_services/topics/service-authorization-obtaining-permission-uma.adoc
@@ -23,7 +23,7 @@ Resource owners are allowed to manage permissions to their resources and decide 
 
 {project_name} is a UMA 2.0 compliant authorization server that provides most UMA capabilities.
 
-As an example, consider a user Alice (resource owner) using an Internet Banking Service (resource server) to manage his Bank Account (resource). One day, Alice decides
+As an example, consider a user Alice (resource owner) using an Internet Banking Service (resource server) to manage her Bank Account (resource). One day, Alice decides
 to open her bank account to Bob (requesting party), a accounting professional. However, Bob should only have access to view (scope) Alice's account.
 
 As a resource server, the Internet Banking Service must be able to protect Alice's Bank Account. For that, it relies on {project_name}


### PR DESCRIPTION
Based on her name and the next sentence, Alice is a woman. So I believe "her" should be used instead.