### PR TITLE
KEYCLOAK-16945 Linking to metering documents to stay in synch with downstream

### DIFF
--- a/release_notes/master.adoc
+++ b/release_notes/master.adoc
@@ -3,11 +3,14 @@
 :linkattrs:
 
 include::topics/templates/document-attributes-product.adoc[]
+include::runtimes-common/attributes/runtimes-attributes.adoc[]
 
 :release_notes:
+:context: release_notes
 
 = {releasenotes_name}
 
 == {project_name_full} 7.4.0.GA
 
 include::topics/product/7_4_final.adoc[leveloffset=2]
+include::runtimes-common/ref_runtimes_metering_labels.adoc[leveloffset=2]


### PR DESCRIPTION
See https://issues.redhat.com/browse/KEYCLOAK-16945 
@abstractj Can you approve this?  It's already implemented in downstream. I made one change to the master.adoc to make sure a cherry-pick of the Keycloak master.adoc file does not overwrite the GitLab SSO version of the file.