### PR TITLE
Fix incorrect endpoint description.

### DIFF
--- a/server_admin/topics/sso-protocols/oidc.adoc
+++ b/server_admin/topics/sso-protocols/oidc.adoc
@@ -100,9 +100,9 @@ You can also find these endpoints under "OpenID Endpoint Configuration" in your 
 
 /realms/{realm-name}/protocol/openid-connect/auth::
   This is the URL endpoint for obtaining a temporary code in the Authorization Code Flow or for obtaining tokens via the
-  Implicit Flow, Direct Grants, or Client Grants.
+  Implicit Flow.
 /realms/{realm-name}/protocol/openid-connect/token::
-  This is the URL endpoint for the Authorization Code Flow to turn a temporary code into a token.
+  This is the URL endpoint for obtaining tokens via the Authorization Code Flow, Direct Grants, or Client Grants.
 /realms/{realm-name}/protocol/openid-connect/logout::
   This is the URL endpoint for performing logouts.
 /realms/{realm-name}/protocol/openid-connect/userinfo::


### PR DESCRIPTION
In the direct grants or client grants, we can get tokens from the token endpoint, not the authorization endpoint.