### PR TITLE
[KEYCLOAK-14894] [KEYCLOAK-16760] Update Keycloak documentation for the upgrade to Wildfly 22

### DIFF
--- a/server_admin/topics/authentication/x509.adoc
+++ b/server_admin/topics/authentication/x509.adoc
@@ -337,7 +337,7 @@ Enable TRACE logging under the logging subsystem::
 ----
 ...
     <profile>
-        <subsystem xmlns="urn:jboss:domain:logging:3.0">
+        <subsystem xmlns="urn:jboss:domain:logging:8.0">
 ...
             <logger category="org.keycloak.authentication.authenticators.x509">
                 <level name="TRACE"/>

--- a/topics/templates/document-attributes-community.adoc
+++ b/topics/templates/document-attributes-community.adoc
@@ -103,7 +103,7 @@ endif::[]
 
 :appserver_name: WildFly
 :appserver_dirref: WILDFLY_HOME
-:appserver_version: 21
+:appserver_version: 22
 
 :appserver_doc_base_url: http://docs.wildfly.org/{appserver_version}
 :appserver_socket_link: {appserver_doc_base_url}/Admin_Guide.html#Interfaces_and_ports
@@ -125,7 +125,7 @@ endif::[]
 
 :jdgserver_name: Infinispan
 :jdgserver_version: 9.4.19
-:jdgserver_version_latest: 11.0.3
+:jdgserver_version_latest: 11.0.8
 :jdgserver_crossdcdocs_link: https://infinispan.org/docs/11.0.x/titles/xsite/xsite.html
 
 :fuseVersion: JBoss Fuse 6.3.0 Rollup 12

--- a/topics/templates/document-attributes-product.adoc
+++ b/topics/templates/document-attributes-product.adoc
@@ -150,7 +150,7 @@
 
 :fuse7Version: JBoss Fuse 7.4.0
 
-:subsystem_undertow_xml_urn: urn:jboss:domain:undertow:10.0
-:subsystem_infinispan_xml_urn: urn:jboss:domain:infinispan:9.0
-:subsystem_datasources_xml_urn: urn:jboss:domain:datasources:5.0
+:subsystem_undertow_xml_urn: urn:jboss:domain:undertow:11.0
+:subsystem_infinispan_xml_urn: urn:jboss:domain:infinispan:11.0
+:subsystem_datasources_xml_urn: urn:jboss:domain:datasources:6.0
 :saml_adapter_xsd_urn: https://www.keycloak.org/schema/keycloak_saml_adapter_1_10.xsd

--- a/upgrading/topics/keycloak/changes.adoc
+++ b/upgrading/topics/keycloak/changes.adoc
@@ -1,5 +1,23 @@
 == Migration Changes
 
+=== Migrating to 13.0.0
+
+==== Upgrade to Wildfly 22
+
+The {project_name} server was upgraded to use Wildfly 22 as the underlying container. This does not directly involve any
+specific {project_name} server functionality, but a few changes related to the migration, which are worth mentioning.
+
+Dependency updates::
+  The dependencies were updated to the versions used by Wildfly 22 server. For example, Infinispan is now `11.0.8.Final`.
+
+Configuration changes::
+  A few configuration changes exist in the `standalone(-ha).xml` and `domain.xml` files. You should follow the <<_install_new_version>>
+  section to handle the migration of configuration files automatically. If more detail is needed, because, for example, you did some
+  configuration changes on your own, the list of the most important changes follows:
+  * The link:https://docs.wildfly.org/22/Admin_Guide.html#MicroProfile_Config_SmallRye[Eclipse MicroProfile Config], link:https://docs.wildfly.org/22/Admin_Guide.html#MicroProfile_Health_SmallRye[Eclipse MicroProfile Health], and link:https://docs.wildfly.org/22/Admin_Guide.html#MicroProfile_Metrics_SmallRye[Eclipse MicroProfile Metrics] subsystems were replaced by link:https://docs.wildfly.org/22/Admin_Guide.html#Health[WildFly subsystem for health] and link:https://docs.wildfly.org/22/Admin_Guide.html#MicroProfile_Metrics_SmallRye[WildFly subsystem for base metrics].
+
+  * The default Wildfly configuration now utilizes the ability to make use of an automatically generated self-signed certificate with Elytron. Refer to link:https://docs.wildfly.org/22/WildFly_Elytron_Security.html#update-wildfly-to-use-the-default-elytron-components-for-application-authentication[a dedicated `applicationSSC` server SSL context section] for details.
+
 === Migrating to 12.0.2
 
 ==== Read-only attributes


### PR DESCRIPTION
    [KEYCLOAK-14894] Update versions of (various) URN namespaces to match
    their respective Wildfly 22 counterparts
    
    [KEYCLOAK-16760] Update Keycloak documentation for the upgrade to
    Wildfly 22
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

_Note:_ Needs to be merged together with corresponding:
* [Code](https://github.com/keycloak/keycloak/pull/7705) and
* [Website](https://github.com/keycloak/keycloak-web/pull/163)

changes.

@pskopek @mposolda @andymunro PTAL once got a chance
Thanks, Jan