### PR TITLE
KEYCLOAK-16425 Cleanup documentation regarding the logic for selecting locale

### DIFF
--- a/server_admin/topics/realms/themes.adoc
+++ b/server_admin/topics/realms/themes.adoc
@@ -53,3 +53,6 @@ The logic for selecting the locale uses the first of the following that is avail
 When a user is authenticated an action is triggered to update the locale in the persisted cookie mentioned earlier. If the
 user has actively switched the locale through the locale selector on the login pages the users locale is also updated at
 this point.
+
+If you want to change the logic for selecting the locale, you have an option to create custom `LocaleSelectorProvider`. For details, please refer to the
+link:{developerguide_link}#_locale_selector[{developerguide_name}].

--- a/server_development/topics/locale-selector.adoc
+++ b/server_development/topics/locale-selector.adoc
@@ -1,13 +1,8 @@
 [[_locale_selector]]
 === Locale Selector
 
-By default, the locale is selected using the `DefaultLocaleSelectorProvider` which implements the `LocaleSelectorProvider` interface. English is the default language when internationalization is disabled. With internationalization enabled, the locale is resolved in the following priority:
-
-. `KEYCLOAK_LOCALE` cookie value
-. User's preferred locale if a user instance is available
-. `ui_locales` query parameter
-. `Accept-Language` request header
-. Realm's default language
+By default, the locale is selected using the `DefaultLocaleSelectorProvider` which implements the `LocaleSelectorProvider` interface. English is the default language when internationalization is disabled.
+With internationalization enabled, the locale is resolved according to the logic described in the link:{adminguide_link}#_user_locale_selection[{adminguide_name}].
 
 This behaviour can be changed through the `LocaleSelectorSPI` by implementing the `LocaleSelectorProvider` and `LocaleSelectorProviderFactory`.
 


### PR DESCRIPTION
@andymunro Do you please have a chance to review this PR?

The description of the logic for selecting locale was present on two places in the documentation. PR removes this duplication to reduce the risk of one place being outdated (which is exactly the reason of KEYCLOAK-16425 as the info in the development guide was outdated). Instead of this, there are links for both documentation sections. 