### PR TITLE
KEYCLOAK-17330 Document how to use private extensions

### DIFF
--- a/server_installation/topics/operator/extensions.adoc
+++ b/server_installation/topics/operator/extensions.adoc
@@ -46,3 +46,9 @@ You can package and deploy themes in the same way as any other extensions. See {
 
 The Operator downloads the extension or theme and installs it.
 
+It is possible to use a private extension through the use of an HTTP basic auth URL.
+
+```
+https://username:password@host.com/theme.jar
+```
+


### PR DESCRIPTION
Relies on https://github.com/keycloak/keycloak-operator/pull/340

Adds instructions on how to use HTTP basic auth URLs to access private extensions.