### PR TITLE
KEYCLOAK-16918 Set custom user attribute to Name ID Format for a SAML client

### DIFF
--- a/server_admin/topics/clients/client-saml.adoc
+++ b/server_admin/topics/clients/client-saml.adoc
@@ -116,6 +116,28 @@ Name ID Format::
   Name ID Format for the subject.
   If no name ID policy is specified in the request or if the Force Name ID Format attribute is true, this value is used.
   Properties used for each of the respective formats are defined below.
+  You can change the attribute used by the NameID Mapper.
+
+|===
+|Name ID Format|Properties/Attributes Used|Example
+
+|username (unspecified)
+|Username Property     
+|example_user
+
+|email
+|Email Property
+|example_user@example.com
+
+|persistent
+|saml.persistent.name.id.for.$clientId Attribute
+|G-6e2a1050-0fc0-479b-bf6e-29cd3ccb373b
+
+|transient
+|property and attribute values are not used
+|G-bfb85c10-57d7-4331-81bc-52f104599d79
+
+|===
 
 Root URL::
   If {project_name} uses any configured relative URLs, this value is prepended to them.


### PR DESCRIPTION
https://issues.redhat.com/projects/KEYCLOAK/issues/KEYCLOAK-16918
https://groups.google.com/g/keycloak-dev/c/4ExUdT9rc2g

### NameID Mapper description
I am worried where to add the Mapper description for the SAML client.
This time,I have added instructions only for the SAML client configuration part.

Code PR : https://github.com/keycloak/keycloak/pull/7913