### PR TITLE
KEYCLOAK-17824 Fix ReleaseNotes test failure

### DIFF
--- a/release_notes/topics/13_0_0.adoc
+++ b/release_notes/topics/13_0_0.adoc
@@ -16,7 +16,7 @@ and https://github.com/Michito-Okai[Michito Okai].
 
 Keycloak now supports communication with clients using SAML _Artifact_ binding. A new `Force Artifact Binding` option
 was introduced in the client configuration, that forces communication with the client using artifact messages. For more
-details proceed to link:{adminguide_link_latest}#_client_saml_configuration[{adminguide_name}]. Please note, that with
-this version, Keycloak SAML client adapter does NOT support _Artifact_ binding.
+details proceed to link:{adminguide_link}#_client-saml-configuration[{adminguide_name}]. Please note, that with
+this version, Keycloak SAML client adapter does NOT support Artifact binding.
 
 Thanks to https://github.com/AlistairDoswald[AlistairDoswald] and https://github.com/harture[harture].

--- a/server_admin/topics/clients/client-saml.adoc
+++ b/server_admin/topics/clients/client-saml.adoc
@@ -1,4 +1,4 @@
-[[_client_saml_configuration]]
+[[_client-saml-configuration]]
 === SAML Clients
 
 {project_name} supports <<_saml,SAML 2.0>> for registered applications.


### PR DESCRIPTION
The failure was caused by the false matching of `_` in adminguide link with `_` around Artifact. I fixed by removing _ around Artifact, if you have any idea how to fix this without removing it please let me know I will update.  