### PR TITLE
[KEYCLOAK-17902] Fix failures of 'org.keycloak.documentation.test.ReleaseNotesTest' when building product documentation

### DIFF
--- a/release_notes/master.adoc
+++ b/release_notes/master.adoc
@@ -3,7 +3,6 @@
 :linkattrs:
 
 include::topics/templates/document-attributes-product.adoc[]
-include::runtimes-common/attributes/runtimes-attributes.adoc[]
 
 :release_notes:
 :context: release_notes
@@ -15,4 +14,14 @@ include::topics/templates/making-open-source-more-inclusive.adoc[]
 == {project_name_full} 7.4.0.GA
 
 include::topics/product/7_4_final.adoc[leveloffset=2]
+
+ifeval::[{project_product}==true]
+
+// Define attributes expected by metering labels
+:ProductName: {project_name}
+:component-name: {project_name}
+:component-version: {project_version_base}
+// Include the metering labels
+include::runtimes-common/attributes/runtimes-attributes.adoc[]
 include::runtimes-common/ref_runtimes_metering_labels.adoc[leveloffset=2]
+endif::[]

--- a/release_notes/runtimes-common
+++ b/release_notes/runtimes-common
@@ -1,0 +1,1 @@
+../runtimes-common/

--- a/runtimes-common/attributes/runtimes-attributes.adoc
+++ b/runtimes-common/attributes/runtimes-attributes.adoc
@@ -1,0 +1,44 @@
+//
+// This file contains attributes for Red Hat Runtimes product docs.
+//
+
+//
+//Metering labels: product specific
+//
+
+//Each product team must uniquely define two attributes in their projects.
+//This file gets automatically overwritten so treat it as READ only!!
+
+//Define the correct product version.
+//:component-version: x.y.z
+
+//Define the component name.
+//:component-name: "Data_Grid"
+//:component-name: "Vert.X"
+//:component-name: "EAP"
+//:component-name: "JBoss_Web_Server"
+//:component-name: "SSO"
+//:component-name: "AMQ_Broker"
+//:component-name: "Quarkus"
+//:component-name: "Spring_Boot"
+//:component-name: "Thorntail"
+//:component-name: "Node.js"
+
+//Be sure ProductName resolves if you don't already define it.
+//:ProductName: Data Grid
+
+//
+//Metering labels: common
+//
+
+//These metering labels apply to all Runtimes products. Do not change them.
+
+:component-type: application
+:product-name: "Red_Hat_Runtimes"
+:product-version: 2020/Q2
+
+//
+//Links
+//
+
+:metering-doc-root: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/metering/index

--- a/runtimes-common/ref_runtimes_metering_labels.adoc
+++ b/runtimes-common/ref_runtimes_metering_labels.adoc
@@ -1,0 +1,26 @@
+//Include this reference module in product release notes.
+//Be sure you declare runtimes-attributes.doc
+//Content is intended for runtimes doc projects.
+
+[id='runtimes_metering_labels-{context}']
+= {ProductName} metering labels for Red Hat OpenShift
+
+You can add metering labels to your {ProductName} pods and check Red Hat subscription details with the OpenShift Metering Operator.
+
+[NOTE]
+====
+Do not add metering labels to any pods that an operator deploys and manages.
+====
+
+{ProductName} can use the following metering labels:
+
+* `com.redhat.component-name: {component-name}`
+* `com.redhat.component-type: {component-type}`
+* `com.redhat.component-version: {component-version}`
+* `com.redhat.product-name: {product-name}`
+* `com.redhat.product-version: {product-version}`
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:{metering-doc-root}[Configuring and using Metering in OpenShift Container Platform]


### PR DESCRIPTION
    [KEYCLOAK-17902] Fix failures of 'org.keycloak.documentation.test.ReleaseNotesTest'
    when building product documentation
    
    * Add the two referenced, but (so far) missing files to include,
    * Define the attributes expected by metering labels
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

@andymunro @oraNod PTAL once got a chance (pls also see a comment / RFC below)

Thanks,
Jan