### PR TITLE
KEYCLOAK-17924 CIBA feature misplaced in documentation

### DIFF
--- a/server_installation/topics/profiles.adoc
+++ b/server_installation/topics/profiles.adoc
@@ -29,6 +29,11 @@ The features that can be enabled and disabled are:
 |No
 |Preview
 
+|ciba
+|OpenID Connect Client Initiated Backchannel Authentication (CIBA)
+|No
+|Preview
+
 |client_policies
 |Add client configuration policies
 |No
@@ -76,11 +81,6 @@ ifeval::[{project_product}==true]
 |No
 |Preview
 endif::[]
-
-|ciba
-|OpenID Connect Client Initiated Backchannel Authentication (CIBA)
-|No
-|Preview
 
 |===
 


### PR DESCRIPTION
Prevent CIBA entry and WebAuthN entry to get mixed up