### PR TITLE
KEYCLOAK-9725 Fixing cross-references to Server Administration Guide

### DIFF
--- a/securing_apps/topics/oidc/java/params_forwarding.adoc
+++ b/securing_apps/topics/oidc/java/params_forwarding.adoc
@@ -17,7 +17,13 @@ and the parameter `scope=offline_access` will be automatically forwarded to the 
 
 The supported parameters are:
 
-* scope - Use a space-delimited list of scopes. A space-delimited list typically references link:{adminguide_link}#_client_scopes[Client scopes]
+* scope - Use a space-delimited list of scopes. A space-delimited list typically references
+ifeval::[{project_community}==true]
+link:{adminguide_link}#_client_scopes[Client scopes]
+endif::[]
+ifeval::[{project_product}==true]
+link:{adminguide_link}#client_scopes[Client scopes]
+endif::[]
 defined on particular client. Note that the scope `openid` will be always be added to the list of scopes by the adapter. For example, if you
 enter the scope options `address phone`, then the request to {project_name} will contain the scope parameter `scope=openid address phone`.
 

--- a/securing_apps/topics/oidc/javascript-adapter.adoc
+++ b/securing_apps/topics/oidc/javascript-adapter.adoc
@@ -225,8 +225,8 @@ While this mode is easy to setup, it also has some disadvantages:
 
 Use this example app to help you get started: https://github.com/keycloak/keycloak/tree/master/examples/cordova
 
-The alternative mode `cordova-native` takes a different approach. 
-It opens the login page using the system's browser. 
+The alternative mode `cordova-native` takes a different approach.
+It opens the login page using the system's browser.
 After the user has authenticated, the browser redirects back into the app using a special URL.
 From there, the {project_name} adapter can finish the login by reading the code or token from the URL.
 
@@ -249,7 +249,7 @@ Please refer to the Android and iOS sections of the https://github.com/e-imaxina
 
 There are different kinds of links for opening apps: custom schemes (i.e. `myapp://login` or `android-app://com.example.myapp/https/example.com/login`) and https://developer.apple.com/ios/universal-links/[Universal Links (iOS)]) / https://developer.android.com/training/app-links/deep-linking[Deep Links (Android)].
 While the former are easier to setup and tend to work more reliably, the later offer extra security as they are unique and only the owner of a domain can register them.
-Custom-URLs are deprecated on iOS. 
+Custom-URLs are deprecated on iOS.
 We recommend that you use universal links, combined with a fallback site with a custom-url link on it for best reliability.
 
 Furthermore, we recommend the following steps to improve compatibility with the Keycloak Adapter:
@@ -259,7 +259,7 @@ Furthermore, we recommend the following steps to improve compatibility with the 
 
 [source,xml]
 ----
-<preference name="AndroidLaunchMode" value="singleTask" /> 
+<preference name="AndroidLaunchMode" value="singleTask" />
 ----
 
 There is an example app that shows how to use the native-mode: https://github.com/keycloak/keycloak/tree/master/examples/cordova-native
@@ -404,7 +404,7 @@ responseMode::
 
 flow::
     Flow passed in init.
-    
+
 adapter::
     Allows you to override the way that redirects and other browser-related functions will be handled by the library.
     Available options:
@@ -454,8 +454,9 @@ For example enforce displaying the login screen in case of value `login`. See li
 for the details and all the possible values of the `prompt` parameter.
 * maxAge - Used just if user is already authenticated. Specifies maximum time since the authentication of user happened. If user is already authenticated for longer time than `maxAge`, the SSO is ignored and he will need to re-authenticate again.
 * loginHint - Used to pre-fill the username/email field on the login form.
-* scope - Used to forward the scope parameter to the {project_name} login endpoint. Use a space-delimited list of scopes. Those typically
-reference link:{adminguide_link}#_client_scopes[Client scopes] defined on particular client. Note that the scope `openid` will be
+* scope - Used to forward the scope parameter to the {project_name} login endpoint. Use a space-delimited list of scopes. Those typically referenece 
+link:{adminguide_clientscopes_link}[Client scopes]
+defined on a particular client. Note that the scope `openid` will be
 always be added to the list of scopes by the adapter. For example, if you enter the scope options `address phone`, then the request
 to {project_name} will contain the scope parameter `scope=openid address phone`.
 * idpHint - Used to tell {project_name} to skip showing the login page and automatically redirect to the specified identity

--- a/topics/templates/document-attributes-community.adoc
+++ b/topics/templates/document-attributes-community.adoc
@@ -51,6 +51,7 @@ endif::[]
 :adminguide_timeouts_link: {adminguide_link}#_timeouts
 :adminguide_clearcache_name: Clearing Server Caches
 :adminguide_clearcache_link: {adminguide_link}#_clear-cache
+:adminguide_clientscopes_link: {adminguide_link}#_client_scopes
 :apidocs_name: API Documentation
 :apidocs_link: https://www.keycloak.org/docs/{project_versionDoc}/api_documentation/
 :developerguide_name: Server Developer Guide

--- a/topics/templates/document-attributes-product.adoc
+++ b/topics/templates/document-attributes-product.adoc
@@ -48,6 +48,7 @@
 :adminguide_timeouts_link: {adminguide_link}#_timeouts
 :adminguide_clearcache_name: Clearing Server Caches
 :adminguide_clearcache_link: {adminguide_link}#_clear-cache
+:adminguide_clientscopes_link: {adminguide_link}#client_scopes
 :apidocs_name: API Documentation
 :apidocs_link: {project_doc_base_url}/api_documentation/index
 :developerguide_name: Server Developer Guide


### PR DESCRIPTION
@sguilhen Can you check this one?

For some reason, the use of #_client_scopes cannot work in both the upstream downstream docs. I had to use conditional clauses for the two occurrences of this cross-reference.