### PR TITLE
KEYCLOAK-18272 CIBA Documentation : Authentication Delegation Response status is 201, not 204

### DIFF
--- a/server_admin/topics/sso-protocols/oidc.adoc
+++ b/server_admin/topics/sso-protocols/oidc.adoc
@@ -248,7 +248,7 @@ Authentication Delegation Response:: The response is returned from the authentic
 |===
 |HTTP Status Code|Description
 
-|204|It notifies {project_name} of receiving the authentication delegation request.
+|201|It notifies {project_name} of receiving the authentication delegation request.
 
 |===
 


### PR DESCRIPTION
This PR is for [KEYCLOAK-12137 OpenID Connect Client Initiated Backchannel Authentication (CIBA)](https://issues.redhat.com/browse/KEYCLOAK-12137), also is the part of the project [FAPI-CIBA(poll mode)](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

This PR fixes its documentation bug. Its details can be shown in [KEYCLOAK-18272](https://issues.redhat.com/browse/KEYCLOAK-18272).