### PR TITLE
fix: add information about npm pkg

### DIFF
--- a/securing_apps/topics/oidc/javascript-adapter.adoc
+++ b/securing_apps/topics/oidc/javascript-adapter.adoc
@@ -7,6 +7,8 @@ The library can be retrieved directly from the {project_name} server at `/auth/j
 
 A best practice is to load the JavaScript adapter directly from {project_name} Server as it will automatically be updated when you upgrade the server. If you copy the adapter to your web application instead, make sure you upgrade the adapter only after you have upgraded the server.
 
+NOTE: You can also download package from npm: https://www.npmjs.com/package/keycloak-js
+
 One important thing to note about using client-side applications is that the client has to be a public client as there is no secure way to store client
 credentials in a client-side application. This makes it very important to make sure the redirect URIs you have configured for the client are correct and as specific as possible.
 


### PR DESCRIPTION
I recieved feedback from customer/users that keycloak client side is widely undocumented, which was surprising to see.
After checking I found out that in fact for users that use npm there is no documentation provided:

https://www.npmjs.com/package/keycloak-js

This is very rare to see in NPM for package that have such large number of downloads. 
Additionally official docs doesn't mention NPMand recommend using js package from server (which is not be the best advice in modern app dev - if you do CDN's etc.).

Additionally, some old bower repo is still 3th result in google and since it has some docs people using it:
https://github.com/keycloak/keycloak-js-bower - worth removing this repository as it is still poping up to users from google and has some docs.

## What is in this PR

Added simple note in the docs for NPM package, so hopefully google will position this documentation

## What we can do in Keycloak 

Create simple README.md file to point out to this documentation so NPM will have proper link for users.