### PR TITLE
KEYCLOAK-11019 Offline sessions preloading docs

### DIFF
--- a/server_admin/topics.adoc
+++ b/server_admin/topics.adoc
@@ -95,6 +95,11 @@ include::topics/sessions/administering.adoc[]
 include::topics/sessions/revocation.adoc[]
 include::topics/sessions/timeouts.adoc[]
 include::topics/sessions/offline.adoc[]
+
+ifeval::[{project_community}==true]
+include::topics/sessions/preloading.adoc[]
+endif::[]
+
 include::topics/sessions/transient.adoc[]
 include::topics/user-federation.adoc[]
 include::topics/user-federation/ldap.adoc[]

--- a/server_admin/topics/sessions/preloading.adoc
+++ b/server_admin/topics/sessions/preloading.adoc
@@ -1,0 +1,34 @@
+=== Offline Sessions Preloading
+
+In addition to {jdgserver_name} caches, offline sessions are stored in a database which means they will be available even after server restart.
+By default, the offline sessions are preloaded from the database into the {jdgserver_name} caches during the server startup.
+However this approach has a drawback if there are many offline sessions to be preloaded. It can significantly slow down the server startup time.
+
+To overcome this problem, {project_name} can be configured to fetch offline sessions into the {jdgserver_name} caches on demand.
+It can be achieved by setting `preloadOfflineSessionsFromDatabase` property in `userSessions` SPI to `false`.
+
+The following example shows how to configure lazy offline sessions loading.
+
+[source,xml]
+----     
+<subsystem xmlns="urn:jboss:domain:keycloak-server:1.1">
+    ...
+    <spi name="userSessions">
+        <default-provider>infinispan</default-provider>
+        <provider name="infinispan" enabled="true">
+            <properties>
+                <property name="preloadOfflineSessionsFromDatabase" value="false"/>
+            </properties>
+        </provider>
+    </spi>
+    ...
+</subsystem>
+----
+
+Equivalent configuration using CLI commands:
+
+[source,bash]
+----
+/subsystem=keycloak-server/spi=userSessions:add(default-provider=infinispan)
+/subsystem=keycloak-server/spi=userSessions/provider=infinispan:add(properties={preloadOfflineSessionsFromDatabase => "false"},enabled=true)
+----


### PR DESCRIPTION
@vramik  @andymunro This is the missing piece of documentation for the offline sessions preloading. It should be merged before Keycloak 14 release. If you could review it that would be great. Thanks!