### PR TITLE
Corrected an issue with header injection in HeaderMojo.java

### DIFF
--- a/header-maven-plugin/src/main/java/sample/plugin/HeaderMojo.java
+++ b/header-maven-plugin/src/main/java/sample/plugin/HeaderMojo.java
@@ -114,7 +114,7 @@ public class HeaderMojo extends AbstractMojo {
             try(PrintStream ps = new PrintStream(new FileOutputStream(out));BufferedReader br = new BufferedReader(new FileReader(f));){
                 for (String l = br.readLine(); l != null; l = br.readLine()) {
                     ps.println(l);
-                    if (l.contains("=")) {
+                    if (l.startsWith("=")) {
                         break;
                     }
                 }


### PR DESCRIPTION
This PR corrects an issue with header injection in the HeaderMojo.java file.

Today, the processTopics function attempts to inject a custom header into files by identifying the title of the topic and injecting the header after that on several new lines.

Because the test to identify the header uses .contains instead of .startsWith, the function incorrectly identifies the section to inject the header in files where there is a section ID (for example, 'ID="XYZ') or another line that contains the equals sign. As a result, the header is injected between the section ID in the HTML and the actual title, causing the sidebar to appear in the incorrect location.

This PR changes the function to use 'startsWith' instead, correctly identifying the line on which the file's section title appears, and resolving this issue.

Tested using mvn compile.