### PR TITLE
fix typos on external-dagtabase settings

### DIFF
--- a/server_installation/topics/operator/external-database.adoc
+++ b/server_installation/topics/operator/external-database.adoc
@@ -19,9 +19,9 @@ stringData:
     POSTGRES_HOST: <Database Service Name>
     POSTGRES_PASSWORD: <Database Password>
     # Required for AWS Backup functionality
-    POSTGRES_SUPERUSER: true
+    POSTGRES_SUPERUSER: "true"
     POSTGRES_USERNAME: <Database Username>
- type: Opaque
+type: Opaque
 ```
 
 The following properties set the hostname or IP address and port of the database.


### PR DESCRIPTION
Typo fix: 
1. indent fix
2. bool type fails the stringData.

---
Can you check if steps in this file works well? I failed dozens of times.
This feature to connect with external database is quite important. It will be helpful to provide a much more detailed `keycloak-db-secret.yaml`

Thanks!