### PR TITLE
Add example for `UPDATE_PASSWORD` login action

### DIFF
--- a/securing_apps/topics/oidc/javascript-adapter.adoc
+++ b/securing_apps/topics/oidc/javascript-adapter.adoc
@@ -461,7 +461,7 @@ always be added to the list of scopes by the adapter. For example, if you enter 
 to {project_name} will contain the scope parameter `scope=openid address phone`.
 * idpHint - Used to tell {project_name} to skip showing the login page and automatically redirect to the specified identity
 provider instead. More info in the link:{adminguide_link}#_client_suggested_idp[Identity Provider documentation].
-* action - If value is `register` then user is redirected to registration page, otherwise to login page.
+* action - If value is `register` then user is redirected to registration page, if the value is `UPDATE_PASSWORD` then the user will redirected to the reset password page (if not authenticated will send user to login page first and redirect after authenticated), otherwise to login page.
 * locale - Sets the 'ui_locales' query param in compliance with https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest[section 3.1.2.1 of the OIDC 1.0 specification].
 * cordovaOptions - Specifies the arguments that are passed to the Cordova in-app-browser (if applicable). Options `hidden` and `location` are not affected by these arguments. All available options are defined at https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-inappbrowser/. Example of use: `{ zoom: "no", hardwareback: "yes" }`;
 


### PR DESCRIPTION
Keycloak has a standard way to create a reset password URL from the JS-adapter but the docs don't mention the option, I could only find it [here](https://github.com/keycloak/keycloak/blob/cd342ad5714f15db1cc8b0cd55b788e6543c6dc8/examples/js-console/src/main/webapp/index.html#L26) and had to implement to understand what to expect.

This simple example could have saved me a few hours.