### PR TITLE
Add Java 11 option and change JDK to JRE

### DIFF
--- a/server_installation/topics/installation/system-requirements.adoc
+++ b/server_installation/topics/installation/system-requirements.adoc
@@ -4,7 +4,7 @@
 These are the requirements to run the {project_name} authentication server:
 
 * Can run on any operating system that runs Java
-* Java 8 JDK
+* Java 8 JRE or Java 11 JRE
 * zip or gzip and tar
 * At least 512M of RAM
 * At least 1G of diskspace


### PR DESCRIPTION
Keycloak can be run with Java 8 or Java 11, and the system requirements should reflect this.

Also, a full JDK isn't needed to run Keycloak. Only a JRE is required when using one of the pre-compiled artifacts.