### PR TITLE
KEYCLOAK-19265 Making API link work from API Documentation

### DIFF
--- a/topics/templates/document-attributes-product.adoc
+++ b/topics/templates/document-attributes-product.adoc
@@ -115,7 +115,7 @@
 :apidocs_javadocs_name: JavaDocs Documentation
 :apidocs_javadocs_link: https://access.redhat.com/webassets/avalon/d/red-hat-single-sign-on/version-{project_versionDoc}/javadocs/
 :apidocs_adminrest_name: Administration REST API
-:apidocs_adminrest_link: https://access.redhat.com/webassets/avalon/d/red-hat-single-sign-on/version-{project_versionDoc}/restapi/
+:apidocs_adminrest_link: https://access.redhat.com/webassets/avalon/d/red-hat-single-sign-on/version-{project_versionDoc}/restapi/index.html
 
 :appserver_name: JBoss EAP
 :appserver_dirref: EAP_HOME


### PR DESCRIPTION
@pedroigor This is a minor correction to make sure the API documentation link works.  Please approve.