### PR TITLE
Remove warning when adding OpenShift client via oc create in OCP4

### DIFF
--- a/server_admin/topics/identity-broker/social/openshift.adoc
+++ b/server_admin/topics/identity-broker/social/openshift.adoc
@@ -58,7 +58,7 @@ You can register your client using `oc` command line tool.
 ----
 $ oc create -f <(echo '
 kind: OAuthClient
-apiVersion: v1
+apiVersion: oauth.openshift.io/v1
 metadata:
  name: keycloak-broker <1>
 secret: "..." <2>


### PR DESCRIPTION
The apiVersion field of the OpenShift4 Social Identity Provider example as per the docs is only set to `v1` at the moment. 

This leads to the warning one could see in the attached picture, stating this non-groupified API is deprecated and will be removed in the future. This small PR adds the appropriate apiVersion for the `oc create` example.

![Screenshot 2021-09-15 at 15 43 14](https://user-images.githubusercontent.com/89905860/133446822-50c7d346-c619-49f5-88b3-0539a674a8e8.png)
