### PR TITLE
Verifying variable is set correctly for openshift_openj9_image_repository

### DIFF
--- a/openshift-openj9/master-docinfo.xml
+++ b/openshift-openj9/master-docinfo.xml
@@ -10,7 +10,7 @@
     <orgname>Red Hat Customer Content Services</orgname>
 </authorgroup>
 <legalnotice lang="en-US" version="5.0" xmlns="http://docbook.org/ns/docbook">
-  <para> 		Copyright <trademark class="copyright"></trademark> 2020 Red Hat, Inc. 	</para>
+  <para> 		Copyright <trademark class="copyright"></trademark> 2021 Red Hat, Inc. 	</para>
   <para>Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at</para>


### PR DESCRIPTION
@pedroigor Can you veriify this looks okay.  It builds correctly for SSO.  

The published version shows this variable is not set correctly, but when I build it looks okay.  See this published version where it shows the variable name not the defintiton

https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html-single/red_hat_single_sign-on_for_openshift_on_eclipse_openj9/index