### PR TITLE
Update spring-security-adapter.adoc

### DIFF
--- a/securing_apps/topics/oidc/java/spring-security-adapter.adoc
+++ b/securing_apps/topics/oidc/java/spring-security-adapter.adoc
@@ -72,7 +72,12 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter
     @Bean
     @Override
     protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
-        return new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl());
+        return new RegisterSessionAuthenticationStrategy(buildSessionRegistry());
+    }
+
+    @Bean
+    protected SessionRegistry buildSessionRegistry() {
+        return new SessionRegistryImpl();
     }
 
     @Override


### PR DESCRIPTION
We could confirm a memory leak due to the SessionRegistryImpl not created as a separate bean and thus not processing SessionDestroyedEvents. As described in the linked topic (https://keycloak.discourse.group/t/outofmemory-in-sessionregistryimpl-spring-security-adapter-config/6814) this resulted in sessions never being destroyed until the applications went unresponsive because the heap was full.