### PR TITLE
KEYCLOAK-19800 Fixing attribute used in API documentation

### DIFF
--- a/topics/templates/document-attributes-product.adoc
+++ b/topics/templates/document-attributes-product.adoc
@@ -121,7 +121,7 @@
 :apidocs_javadocs_name: JavaDocs Documentation
 :apidocs_javadocs_link: https://access.redhat.com/webassets/avalon/d/red-hat-single-sign-on/version-{project_versionDoc}/javadocs/
 :apidocs_adminrest_name: Administration REST API
-:apidocs_adminrest_link: https://access.redhat.com/webassets/avalon/d/red-hat-single-sign-on/version-{project_versionDoc}/restapi/
+:apidocs_adminrest_link: https://access.redhat.com/webassets/avalon/d/red-hat-single-sign-on/version-{project_versionDoc}/rest-api/
 
 :appserver_name: JBoss EAP
 :appserver_dirref: EAP_HOME


### PR DESCRIPTION
@hmlnarik Can you approve and merge this minor correction?  The correct link is rest-api, not restapi.  I did a workaround at 7.5, but for 7.5.1, we need to use the actual directory name: rest-api.