### PR TITLE
1311 - Changing RPM command to add a DASH before eap6

### DIFF
--- a/securing_apps/topics/oidc/java/jboss-adapter-rpms.adoc
+++ b/securing_apps/topics/oidc/java/jboss-adapter-rpms.adoc
@@ -80,7 +80,7 @@ $ sudo subscription-manager repos --enable=jb-eap-6-for-rhel-<RHEL_VERSION>-serv
 +
 [source,bash,subs="attributes+"]
 ----
-$ sudo yum install keycloak-adapter-sso7_5eap6
+$ sudo yum install keycloak-adapter-sso7_5-eap6
 ----
 +
 NOTE: The default EAP_HOME path for the RPM installation is /opt/rh/eap6/root/usr/share/wildfly.


### PR DESCRIPTION
Updating Securing Apps guide to use sso7_5 in the RPM commands

@pdrozd, @pskopek Can you review this update?