### PR TITLE
#409 improve docs for KeycloakUser password generation

### DIFF
--- a/server_admin/topics/authentication/kerberos.adoc
+++ b/server_admin/topics/authentication/kerberos.adoc
@@ -128,7 +128,7 @@ When you install https://www.docker.com/[docker], run a docker image with the Fr
 
 ===== ApacheDS testing Kerberos server
 
-For quick testing and unit tests, use a simple http://directory.apache.org/apacheds/[ApacheDS] Kerberos server. You must build {project_name} from the source and then run the Kerberos server with the maven-exec-plugin from our test suite. See details
+For quick testing and unit tests, use a simple https://directory.apache.org/apacheds/[ApacheDS] Kerberos server. You must build {project_name} from the source and then run the Kerberos server with the maven-exec-plugin from our test suite. See details
 https://github.com/keycloak/keycloak/blob/main/docs/tests.md#kerberos-server[here].
 endif::[]
 

--- a/server_installation/topics/operator/keycloak-user-cr.adoc
+++ b/server_installation/topics/operator/keycloak-user-cr.adoc
@@ -23,6 +23,9 @@ spec:
     email: "user@example.com"
     enabled: True
     emailVerified: False
+    credentials:
+      - type: "password"
+        value: "12345"
     realmRoles:
       - "offline_access"
     clientRoles:
@@ -70,8 +73,10 @@ image:images/realm_user.png[]
 
 .Results
 
-After a user is created, the Operator creates a Secret containing the both username and password using the
-following naming pattern: `credential-<realm name>-<username>-<namespace>`. Here's an example:
+After a user is created, the Operator creates a Secret using the
+following naming pattern: `credential-<realm name>-<username>-<namespace>` , containing the username and, if it has been specified in the credentials attribute, the password. If no password is specified Keycloak will create a random one, but it won't be populated in this Secret.
+
+Here's an example:
 
 .`KeycloakUser` Secret
 ```yaml

--- a/server_installation/topics/operator/keycloak-user-cr.adoc
+++ b/server_installation/topics/operator/keycloak-user-cr.adoc
@@ -74,7 +74,7 @@ image:images/realm_user.png[]
 .Results
 
 After a user is created, the Operator creates a Secret using the
-following naming pattern: `credential-<realm name>-<username>-<namespace>` , containing the username and, if it has been specified in the credentials attribute, the password.
+following naming pattern: `credential-<realm name>-<username>-<namespace>`, containing the username and, if it has been specified in the CR `credentials` attribute, the password.
 
 Here's an example:
 

--- a/server_installation/topics/operator/keycloak-user-cr.adoc
+++ b/server_installation/topics/operator/keycloak-user-cr.adoc
@@ -74,7 +74,7 @@ image:images/realm_user.png[]
 .Results
 
 After a user is created, the Operator creates a Secret using the
-following naming pattern: `credential-<realm name>-<username>-<namespace>` , containing the username and, if it has been specified in the credentials attribute, the password. If no password is specified Keycloak will create a random one, but it won't be populated in this Secret.
+following naming pattern: `credential-<realm name>-<username>-<namespace>` , containing the username and, if it has been specified in the credentials attribute, the password.
 
 Here's an example:
 


### PR DESCRIPTION
Issue : [#409](https://github.com/keycloak/keycloak-operator/issues/409)

Current docs are saying that password is automatically generated and stored in a Secret after a KeycloakUser is created. 
That's wrong. The password is only stored in the secret if the attribute `credentials` is specified in the CR.