### PR TITLE
Fix include styles from the parent theme example

### DIFF
--- a/server_development/topics/themes.adoc
+++ b/server_development/topics/themes.adoc
@@ -160,9 +160,7 @@ to:
 
 [source]
 ----
-styles=web_modules/@fontawesome/fontawesome-free/css/icons/all.css web_modules/@patternfly/react-core/dist/styles/base.css
-web_modules/@patternfly/react-core/dist/styles/app.css node_modules/patternfly/dist/css/patternfly.min.css
-node_modules/patternfly/dist/css/patternfly-additions.min.css css/login.css css/styles.css
+styles=web_modules/@fontawesome/fontawesome-free/css/icons/all.css web_modules/@patternfly/react-core/dist/styles/base.css web_modules/@patternfly/react-core/dist/styles/app.css node_modules/patternfly/dist/css/patternfly.min.css node_modules/patternfly/dist/css/patternfly-additions.min.css css/login.css css/styles.css
 ----
 
 NOTE: To override styles from the parent stylesheets it's important that your stylesheet is listed last.


### PR DESCRIPTION
The example in the docs does not work because of the new lines. All styles must be separated with a simple whitespace.