### PR TITLE
Fix description of changing effective roles in scope mappings

### DIFF
--- a/server_admin/topics/roles-groups/con-role-scope-mappings.adoc
+++ b/server_admin/topics/roles-groups/con-role-scope-mappings.adoc
@@ -13,7 +13,7 @@ By default, each client gets all the role mappings of the user. You can view the
 .Full scope
 image:{project_images}/full-client-scope.png[Full scope]
 
-By default, the effective roles of scopes are every declared role in the realm. To change this default behavior, toggle *Full Scope Allowed* to *ON* and declare the specific roles you want in each client.  You can also use <<_client_scopes, client scopes>> to define the same role scope mappings for a set of clients.
+By default, the effective roles of scopes are every declared role in the realm. To change this default behavior, set the *Full Scope Allowed* option to *OFF* and declare the specific roles you want in each client.  You can also use <<_client_scopes, client scopes>> to define the same role scope mappings for a set of clients.
 
 .Partial scope
 image:{project_images}/client-scope.png[Partial scope]

--- a/server_admin/topics/roles-groups/con-role-scope-mappings.adoc
+++ b/server_admin/topics/roles-groups/con-role-scope-mappings.adoc
@@ -13,7 +13,7 @@ By default, each client gets all the role mappings of the user. You can view the
 .Full scope
 image:{project_images}/full-client-scope.png[Full scope]
 
-By default, the effective roles of scopes are every declared role in the realm. To change this default behavior, set the *Full Scope Allowed* option to *OFF* and declare the specific roles you want in each client.  You can also use <<_client_scopes, client scopes>> to define the same role scope mappings for a set of clients.
+By default, the effective roles of scopes are every declared role in the realm. To change this default behavior, toggle *Full Scope Allowed* to *OFF* and declare the specific roles you want in each client.  You can also use <<_client_scopes, client scopes>> to define the same role scope mappings for a set of clients.
 
 .Partial scope
 image:{project_images}/client-scope.png[Partial scope]


### PR DESCRIPTION
* replace 'ON' with 'OFF' when specifying the 'Full Scope Allowed' option value that enables changing the default mappings