### PR TITLE
Add example for mapping role names between Keycloak and Spring Boot

### DIFF
--- a/securing_apps/topics/oidc/java/spring-security-adapter.adoc
+++ b/securing_apps/topics/oidc/java/spring-security-adapter.adoc
@@ -193,8 +193,32 @@ Spring Security, when using role-based authentication, requires that role names 
 For example, an administrator role must be declared in Keycloak as `ROLE_ADMIN` or similar, not simply `ADMIN`.
 
 The class `org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider`            supports an optional `org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper`            which can be used to map roles coming from Keycloak to roles recognized by Spring Security.
-Use, for example, `org.springframework.security.core.authority.mapping.SimpleAuthorityMapper` to insert the `ROLE_` prefix and convert the role name to upper case.
-The class is part of Spring Security Core module.
+Use, for example, `org.springframework.security.core.authority.mapping.SimpleAuthorityMapper` which allows for case conversion and the addition of a prefix (which defaults to `ROLE_`).
+The following code will convert the role names to upper case and, by default, add the `ROLE_` prefix to them:
+
+[source,java]
+----
+@KeycloakConfiguration
+public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
+
+    @Autowired
+    public void configureGlobal(AuthenticationManagerBuilder auth) {
+        auth.authenticationProvider(getKeycloakAuthenticationProvider());
+    }
+
+    private KeycloakAuthenticationProvider getKeycloakAuthenticationProvider() {
+        KeycloakAuthenticationProvider authenticationProvider = keycloakAuthenticationProvider();
+        SimpleAuthorityMapper mapper = new SimpleAuthorityMapper();
+        mapper.setConvertToUpperCase(true);
+        authenticationProvider.setGrantedAuthoritiesMapper(mapper);
+
+        return authenticationProvider;
+    }
+
+    ...
+}
+
+----
 
 ===== Client to Client Support
 

--- a/securing_apps/topics/oidc/java/spring-security-adapter.adoc
+++ b/securing_apps/topics/oidc/java/spring-security-adapter.adoc
@@ -193,7 +193,7 @@ Spring Security, when using role-based authentication, requires that role names 
 For example, an administrator role must be declared in Keycloak as `ROLE_ADMIN` or similar, not simply `ADMIN`.
 
 The class `org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider`            supports an optional `org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper`            which can be used to map roles coming from Keycloak to roles recognized by Spring Security.
-Use, for example, `org.springframework.security.core.authority.mapping.SimpleAuthorityMapper` which allows for case conversion and the addition of a prefix (which defaults to `ROLE_`).
+Use, for example, `org.springframework.security.core.authority.mapping.SimpleAuthorityMapper`, which allows for case conversion and the addition of a prefix (which defaults to `ROLE_`).
 The following code will convert the role names to upper case and, by default, add the `ROLE_` prefix to them:
 
 [source,java]


### PR DESCRIPTION
The reason for this PR is the ambiguity regarding the setting of the role name prefix. I've seen many Keycloak-Spring Boot tutorials where the `ROLE_` prefix was explicitly set which was redundant as the `SimpleAuthorityMapper` defaults to the correct prefix.

Since Spring's documentation for this mapper is very clear, I suspect that unnecessary configuration may come from a misunderstanding of the _"Use (…) `SimpleAuthorityMapper` to insert the `ROLE_` prefix"_. I think the code example I suggest can reduce superfluous configuration in many projects that rely on this mapper.

Furthermore, the example shows how to convert role names to upper case.
