### PR TITLE
Add OIDC Back-channel logout endpoint

### DIFF
--- a/server_admin/topics/sso-protocols/con-server-oidc-uri-endpoints.adoc
+++ b/server_admin/topics/sso-protocols/con-server-oidc-uri-endpoints.adoc
@@ -17,6 +17,9 @@ https://localhost:8080/auth
 
 /realms/{realm-name}/protocol/openid-connect/logout::
   Used for performing logouts.
+  
+/realms/{realm-name}/protocol/openid-connect/logout/backchannel-logout::
+  Used for performing OIDC Back-channel logouts.
 
 /realms/{realm-name}/protocol/openid-connect/userinfo::
   Used for the User Info service described in the OIDC specification.


### PR DESCRIPTION
I had trouble finding this in documentation when trying to set up two connected keycloak instances to perform a backchannel logout. I finally found the URL `/realms/{realm-name}/protocol/openid-connect/logout/backchannel-logout` by reading the source code of the LogoutEndpoint

https://github.com/keycloak/keycloak/blob/bfce612641a70e106b20b136431f0e4046b5c37f/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java#L287