### PR TITLE
KEYCLOAK-14055: Add SASL EXTERNAL authentication for LDAP federation

### DIFF
--- a/server_admin/topics/user-federation/ldap.adoc
+++ b/server_admin/topics/user-federation/ldap.adoc
@@ -70,13 +70,18 @@ Enable Kerberos/SPNEGO authentication in the realm with user data provisioned fr
 Other options::
 Hover the mouse pointer over the tooltips in the Admin Console to see more details about these options.
 
-==== Connecting to LDAP over SSL
+==== Connecting to LDAP using TLS
 
-When you configure a secure connection URL to your LDAP store (for example,`ldaps://myhost.com:636`), {project_name} uses SSL to communicate with the LDAP server. Configure a truststore on the {project_name} server side so that {project_name} can trust the SSL connection to LDAP.
+{project_name} supports securing the connection to the LDAP server with StartTLS and LDAPS.
+LDAPS is configured by using connection URL `ldaps://` (for example,`ldaps://myhost.com:636`) and StartTLS by using `ldap://` together with `Enable StartTLS` selected.
 
-Configure the global truststore for {project_name} with the Truststore SPI. For more information about configuring the global truststore, see the link:{installguide_link}[{installguide_name}]. If you do not configure the Truststore SPI, the truststore falls back to the default mechanism provided by Java, which can be the file supplied by the `javax.net.ssl.trustStore` system property or the cacerts file from the JDK if the system property is unset.
+To verify the LDAP server certificate, configure trusted CA certificates to the global truststore for {project_name} with the Truststore SPI.
+For more information about configuring the global truststore, see the link:{installguide_link}[{installguide_name}]. If you do not configure the Truststore SPI, the truststore falls back to the default mechanism provided by Java, which can be the file supplied by the `javax.net.ssl.trustStore` system property or the cacerts file from the JDK if the system property is unset.
 
 The `Use Truststore SPI` configuration property, in the LDAP federation provider configuration, controls the truststore SPI. By default, {project_name} sets the property to `Only for ldaps`, which is adequate for most deployments.  {project_name} uses the Truststore SPI if the connection URL to LDAP starts with `ldaps` only.
+
+When bind type is set to `SASL EXTERNAL` then {project_name} will use client certificate to authenticate itself to the LDAP server.
+See the link:{installguide_link}[{installguide_name}] for more information how to configure client certificate and private key by using Keystore SPI.
 
 ==== Synchronizing LDAP users to {project_name}
 

--- a/server_installation/topics/network/outgoing.adoc
+++ b/server_installation/topics/network/outgoing.adoc
@@ -235,3 +235,53 @@ hostname-verification-policy::
    `ANY` means that the hostname is not verified. `WILDCARD` Allows wildcards in subdomain names i.e.
   *.foo.com. `STRICT` CN must match hostname exactly.
 
+[[_keystore]]
+==== Outgoing LDAP requests
+
+{project_name} supports authentication towards LDAP server using TLS client certificate as an alternative to simple bind.
+The Keystore SPI is used to configure client certificate and private key for the SASL EXTERNAL authentication mechanism.
+
+WARNING:  By default, a keystore provider is not configured, and any LDAP connections fall back to standard java keystore configuration as described in
+          https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html[Java's JSSE Reference Guide].
+
+You can use _openssl_ to create a new keystore file from existing certificate and private key:
+
+[source]
+----
+openssl pkcs12 -export -passout pass:secret -noiter -nomaciter -in client-cert.pem -inkey client-key.pem -out keystore.p12
+----
+
+The keystore is configured within the `standalone.xml`, `standalone-ha.xml`, or `domain.xml` file in your distribution.
+The location of this file depends on your <<_operating-mode, operating mode>>.
+You can add your keystore configuration by using the following template:
+
+[source,xml]
+----
+<spi name="keystore">
+    <provider name="file" enabled="true">
+        <properties>
+            <property name="file" value="path to your .p12 or .jks file containing client certificate and private key"/>
+            <property name="password" value="password"/>
+            <property name="cache-ttl" value="period of time"/>
+        </properties>
+    </provider>
+</spi>
+----
+
+Possible configuration options for this setting are:
+
+file::
+  The path to a keystore file.
+  This is _REQUIRED_ if any of these properties are defined.
+
+password::
+  Password of the keystore.
+  This is _REQUIRED_ if any of these properties are defined.
+
+cache-ttl::
+  Sets the time to live for in-memory cache of keystore.
+  Keystore is reloaded from disk at the establishment of TLS connection if more time than `cache-ttl` has passed since the keystore was previously loaded.
+  This allows rotation of the certificate and private key without restarting {project_name}.
+  Valid values are for example: `2160h`, `45m`, `120s`.
+  This is _OPTIONAL_.
+  The default value is unlimited (keystore is never reloaded).


### PR DESCRIPTION
This change adds the documentation related to SASL EXTERNAL authentication for LDAP federation, which is being introduced by related PR on Keycloak code repository https://github.com/keycloak/keycloak/pull/7365.

The change additionally clarifies few details regarding TLS use with LDAP by adding information on StartTLS which seemed missing previously.

Signed-off-by: Tero Saarni <tero.saarni@est.tech>