### PR TITLE
Add page about well-known endpoint configuration

### DIFF
--- a/server_admin/topics/sso-protocols.adoc
+++ b/server_admin/topics/sso-protocols.adoc
@@ -6,6 +6,7 @@ This section discusses authentication protocols, the {project_name} authenticati
 include::sso-protocols/con-oidc.adoc[]
 include::sso-protocols/con-oidc-auth-flows.adoc[]
 include::sso-protocols/con-server-oidc-uri-endpoints.adoc[]
+include::sso-protocols/con-server-oidc-wellknown.adoc[]
 include::sso-protocols/con-saml.adoc[]
 include::sso-protocols/con-saml-bindings.adoc[]
 include::sso-protocols/ref-saml-vs-oidc.adoc[]

--- a/server_admin/topics/sso-protocols/con-server-oidc-wellknown.adoc
+++ b/server_admin/topics/sso-protocols/con-server-oidc-wellknown.adoc
@@ -1,0 +1,43 @@
+[id="con-server-oidc-wellknown_{context}"]
+
+====  {project_name} server OIDC well-known endpoint configuration
+[role="_abstract"]
+The {project_name} OIDC `well-known` configuration endpoint can be modified by providing an override file.
+The content of that file will replace the default values returned by the `well-known` endpoint.
+
+The default configuration for the `well-known` endpoint returns all the protocols, authentication flows,
+ciphers and hash algorithms supported by {project_name}. It may be required to limit the advertised options in
+some use cases.
+
+WARNING:  The override file will only modify the `well-known` endpoint configuration. All the options will still be available in the admin console. The override file is also global and will modify the configuration of all realms.
+
+To configure {project_name} to load the override file:
+
+.Procedure 
+
+. Add a configuration for the `well-known` SPI in the {project_name} configuration file.
+
+. Set the value of the `openid-configuration-override` property to the name of the override file
++
+[source, xml]
+----
+<spi name="well-known">
+  <provider name="openid-configuration" enabled="true">
+    <properties>
+      <property name="openid-configuration-override" value="oidc-wellknown-override.json"/>
+      <property name="include-client-scopes" value="true"/>
+    </properties>
+  </provider>
+</spi>
+----
+
+. Create the override file. For example, to limit the response types:
++
+[source, json]
+----
+{
+    "response_types_supported": ["code"]
+}
+----
+
+. Restart the {project_name} server

--- a/server_admin/topics/sso-protocols/con-server-oidc-wellknown.adoc
+++ b/server_admin/topics/sso-protocols/con-server-oidc-wellknown.adoc
@@ -9,7 +9,7 @@ The default configuration for the `well-known` endpoint returns all the protocol
 ciphers and hash algorithms supported by {project_name}. It may be required to limit the advertised options in
 some use cases.
 
-WARNING:  The override file will only modify the `well-known` endpoint configuration. All the options will still be available in the admin console. The override file is also global and will modify the configuration of all realms.
+WARNING:  The override file will only modify the `well-known` endpoint configuration. All the options will still be available in the Admin Console. The override file is also global and will modify the configuration of all realms.
 
 To configure {project_name} to load the override file:
 


### PR DESCRIPTION
Keycloak has a way to specify an override file to modify the content of the well-known endpoint configuration. But it is not documented.

This PR add a new section about this topic and an example configuration to modify the advertised response types.