### PR TITLE
Fix typo in LDAP documentation

### DIFF
--- a/server_admin/topics/user-federation/ldap.adoc
+++ b/server_admin/topics/user-federation/ldap.adoc
@@ -43,7 +43,7 @@ READONLY::
 You cannot change the username, email, first name, last name, and other mapped attributes. {project_name} shows an error anytime a user attempts to update these fields. Password updates are not supported.
 
 WRITABLE::
-You cannot change the username, email, first name, last name, and other mapped attributes and passwords and synchronize them automatically with the LDAP store.
+You can change the username, email, first name, last name, and other mapped attributes and passwords and synchronize them automatically with the LDAP store.
 
 UNSYNCED::
 {project_name} stores changes to the username, email, first name, last name, and passwords in {project_name} local storage, so the administrator must synchronize this data back to LDAP. In this mode, {project_name} deployments can update user metadata on read-only LDAP servers. This option also applies when importing users from LDAP into the local {project_name} user database.


### PR DESCRIPTION
If I'm not mistaken, `cannot` should be read as `can`, shouldn't it?
Based on what I see in the commit history at <https://github.com/keycloak/keycloak-documentation/commit/bb767dcb62cb493a6f56e4bee65843f0649fd483#diff-e66bf4cc8299db5c7ef2b7d9e948a4056298f3e7e3f6d2d24d93591a4f726337L54> anyway.