### PR TITLE
Update classic-war.adoc

### DIFF
--- a/securing_apps/topics/oidc/java/fuse/classic-war.adoc
+++ b/securing_apps/topics/oidc/java/fuse/classic-war.adoc
@@ -94,10 +94,10 @@ To enable the functionality, add this section to your `/WEB_INF/web.xml` file:
 
 [source,xml]
 ----
-<context-param>
+<init-param>
     <param-name>keycloak.config.resolver</param-name>
     <param-value>org.keycloak.adapters.osgi.PathBasedKeycloakConfigResolver</param-value>
-</context-param>
+</init-param>
 ----
 
 That component uses `keycloak.config` or `karaf.etc` java properties to search for a base folder to locate the configuration.


### PR DESCRIPTION
Filter has no `context-param` element, example
```
  <filter>
    <filter-name>Keycloak</filter-name>
    <filter-class>org.keycloak.adapters.servlet.KeycloakOIDCFilter</filter-class>
    <init-param>
      <param-name>keycloak.config.resolver</param-name>
      <param-value>some.package.ResourceContext</param-value>
    </init-param>
  </filter>
```