### PR TITLE
Updating OpenShift guide to match downstream edits

### DIFF
--- a/openshift/master.adoc
+++ b/openshift/master.adoc
@@ -18,4 +18,5 @@ include::topics/templates/document-attributes-product.adoc[]
 
 = {openshift_name}
 
+include::topics/templates/making-open-source-more-inclusive.adoc[]
 include::topics.adoc[]

--- a/openshift/topics.adoc
+++ b/openshift/topics.adoc
@@ -1,5 +1,3 @@
-include::topics/templates/making-open-source-more-inclusive.adoc[]
-
 include::topics/introduction.adoc[leveloffset=+0]
 
 include::topics/get_started.adoc[leveloffset=+0]

--- a/openshift/topics/advanced_concepts.adoc
+++ b/openshift/topics/advanced_concepts.adoc
@@ -574,7 +574,7 @@ Use the xref:sso-administrator-setup[administrator user credentials] to log in i
 Clients are {project_name} entities that request user authentication. A client can be an application requesting {project_name} to provide user authentication, or it can be making requests for access tokens to start services on behalf of an authenticated user. See the link:{project_doc_base_url}/server_administration_guide/index#assembly-managing-clients_server_administration_guide[Managing Clients chapter of the {project_name} documentation] for more information.
 
 {project_name} provides link:{project_doc_base_url}/server_administration_guide/clients#oidc_clients[OpenID-Connect] and link:{project_doc_base_url}/server_administration_guide/index#client-saml-configuration[SAML] client protocols.
-+
+
 OpenID-Connect is the preferred protocol and uses three different access types:
 
 - *public*: Useful for JavaScript applications that run directly in the browser and require no server configuration.

--- a/openshift/topics/get_started.adoc
+++ b/openshift/topics/get_started.adoc
@@ -4,7 +4,7 @@
 === Using the {project_openshift_product_name} Image Streams and application templates
 
 [role="_abstract"]
-Red Hat JBoss Middleware for OpenShift images are pulled on demand from the secured Red Hat Registry: link://https://catalog.redhat.com/[registry.redhat.io], which requires authentication. To retrieve content, you will need to log into the registry using the Red Hat account.
+Red Hat JBoss Middleware for OpenShift images are pulled on demand from the secured Red Hat Registry: link:https://catalog.redhat.com/[registry.redhat.io], which requires authentication. To retrieve content, you will need to log into the registry using the Red Hat account.
 
 To consume container images from *_registry.redhat.io_* in shared environments such as OpenShift, it is recommended for an administrator to use a Registry Service Account, also referred to as authentication tokens, in place of an individual person's Red Hat Customer Portal credentials.
 

--- a/openshift/topics/introduction.adoc
+++ b/openshift/topics/introduction.adoc
@@ -4,7 +4,7 @@
 [role="_abstract"]
 {project_name} is an integrated sign-on solution available as a Red Hat JBoss Middleware for OpenShift containerized image. The {project_openshift_product_name} image provides an authentication server for users to centrally log in, log out, register, and manage user accounts for web applications, mobile applications, and RESTful web services.
 
-{openshift_name} is available only on *{openshift_image_platforms}*. For other available platforms, see link:{openshift_link_other}[{openshift_name_other}].
+{openshift_name} is available on the following platforms: x86_64, IBM Z, and IBM Power Systems.
 
 === Comparison: {project_openshift_product_name} Image versus Red Hat Single Sign-On
 The {project_openshift_product_name} image version number {project_version} is based on {project_name} {project_version}. There are some important differences in functionality between the {project_openshift_product_name} image and {project_name} that should be considered:
@@ -21,11 +21,11 @@ Red Hat offers multiple OpenShift application templates using the {project_opens
 
 These templates require that HTTPS, JGroups keystores, and a truststore for the {project_name} server exist beforehand.  They secure the TLS communication using passthrough TLS termination.
 
-* _{project_templates_version}-https_*: {project_name} {project_version} backed by internal H2 database on the same pod.
+* *_{project_templates_version}-https_*: {project_name} {project_version} backed by internal H2 database on the same pod.
 
-* _{project_templates_version}-postgresql_*: {project_name} {project_version} backed by ephemeral PostgreSQL database on a separate pod.
+* *_{project_templates_version}-postgresql_*: {project_name} {project_version} backed by ephemeral PostgreSQL database on a separate pod.
 
-* _{project_templates_version}-postgresql-persistent_*: {project_name} {project_version} backed by persistent PostgreSQL database on a separate pod.
+* *_{project_templates_version}-postgresql-persistent_*: {project_name} {project_version} backed by persistent PostgreSQL database on a separate pod.
 
 [NOTE]
 Templates for using {project_name} with MySQL / MariaDB databases have been removed and are not available since {project_name} version 7.4.
@@ -37,16 +37,16 @@ These templates use OpenShift's internal link:{ocpdocs_serving_x509_secrets_link
 
 Moreover, the truststore for the {project_name} server is pre-populated with the all known, trusted CA certificate files found in the Java system path. These templates secure the TLS communication using re-encryption TLS termination.
 
-* _{project_templates_version}-x509-https_*: {project_name} {project_version} with auto-generated HTTPS keystore and {project_name} truststore, backed by internal H2 database. The `ASYM_ENCRYPT` JGroups protocol is used for encryption of cluster traffic.
-* _{project_templates_version}-x509-postgresql-persistent_*: {project_name} {project_version} with auto-generated HTTPS keystore and {project_name} truststore, backed by persistent PostgreSQL database. The `ASYM_ENCRYPT` JGroups protocol is used for encryption of cluster traffic.
+* *_{project_templates_version}-x509-https_*: {project_name} {project_version} with auto-generated HTTPS keystore and {project_name} truststore, backed by internal H2 database. The `ASYM_ENCRYPT` JGroups protocol is used for encryption of cluster traffic.
+* *_{project_templates_version}-x509-postgresql-persistent_*: {project_name} {project_version} with auto-generated HTTPS keystore and {project_name} truststore, backed by persistent PostgreSQL database. The `ASYM_ENCRYPT` JGroups protocol is used for encryption of cluster traffic.
 
 ==== Other templates
 
 Other templates that integrate with {project_name} are also available:
 
-* _eap64-sso-s2i_*: {project_name}-enabled Red Hat JBoss Enterprise Application Platform 6.4.
-* _eap71-sso-s2i_*: {project_name}-enabled Red Hat JBoss Enterprise Application Platform 7.1.
-* _datavirt63-secure-s2i_*: {project_name}-enabled Red Hat JBoss Data Virtualization 6.3.
+* *_eap64-sso-s2i_*: {project_name}-enabled Red Hat JBoss Enterprise Application Platform 6.4.
+* *_eap71-sso-s2i_*: {project_name}-enabled Red Hat JBoss Enterprise Application Platform 7.1.
+* *_datavirt63-secure-s2i_*: {project_name}-enabled Red Hat JBoss Data Virtualization 6.3.
 
 These templates contain environment variables specific to {project_name} that enable automatic {project_name} client registration when deployed.
 
@@ -54,8 +54,8 @@ These templates contain environment variables specific to {project_name} that en
 .Additional resources
 
 * xref:Auto-Man-Client-Reg[Automatic and Manual {project_name} Client Registration Methods]
-* link:{ocp311docs_passthrough_route_link}[passthrough TLS termination]
-* link:{ocp311docs_reencrypt_route_link}[re-encryption TLS termination]
+* link:{ocp311docs_passthrough_route_link}[Passthrough TLS termination]
+* link:{ocp311docs_reencrypt_route_link}[Re-encryption TLS termination]
 
 === Version compatibility and support
 For details about OpenShift image version compatibility, see the https://access.redhat.com/articles/2342861[Supported Configurations] page.
@@ -63,4 +63,3 @@ For details about OpenShift image version compatibility, see the https://access.
 NOTE: The {project_openshift_product_name} image version number between 7.0 and 7.3 are deprecated and they will no longer receive updates of image and application templates.
 
 To deploy new applications, use the version 7.4 or {project_version} of the {project_openshift_product_name} image along with the application templates specific to these image versions.
-

--- a/release_notes/topics/product/7_5.adoc
+++ b/release_notes/topics/product/7_5.adoc
@@ -109,6 +109,8 @@ These features have a change in status:
 * Support for Red Hat Single Sign-On (RH-SSO) on Red Hat Enterprise Linux 6 (RHEL 6) is deprecated and the 7.5 release of RH-SSO will not be supported on RHEL 6. RHEL 6 entered the ELS phase of its lifecycle on November 30, 2020 and the Red Hat JBoss Enterprise Application Platform (EAP) that RH-SSO depends upon will drop support for RHEL 6 with the EAP 7.4 release. Customers should deploy their RH-SSO 7.5 upgrades on RHEL 7 or 8 versions.
 * The Spring Boot Adapter is deprecated and will not be included in the 8.0 and higher versions of RH-SSO. This adapter will be maintained during the lifecycle of RH-SSO 7.x. Users are urged to migrate to Spring Security to integrate their Spring Boot applications with RH-SSO.
 * Installation from an RPM is deprecated. Red Hat Single Sign-On will continue to deliver RPMs for the life of the 7.x product, but will not deliver RPMs with the next major version. The product will continue to support installation from a ZIP file and installation on OpenShift.
+* Red Hat Single Sign-On for OpenShift on Eclipse OpenJ9 is deprecated.  However, Red Hat Single Sign-On on OpenShift will now support all platforms (x86, IBM Z, and IBM Power Systems) as documented in the https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/html/red_hat_single_sign-on_for_openshift/index[Red Hat Single Sign-On for OpenShift Guide]. 
+For more details on this change, see link:https://access.redhat.com/articles/6744521[Java Change in PPC and s390x OpenShift Images].
 * Authorization Services Drools Policy has been removed.
 
 * Upload of scripts through admin rest endpoints/console is deprecated. It will be removed at a future release.

--- a/topics/templates/document-attributes-product.adoc
+++ b/topics/templates/document-attributes-product.adoc
@@ -76,7 +76,7 @@
 :releasenotes_name: Release Notes
 :releasenotes_link: {project_doc_base_url}/release_notes/
 :openshift_image_repository_productline: rh-sso-7
-:openshift_openjdk_name: Red Hat Single Sign-On for OpenShift on OpenJDK
+:openshift_openjdk_name: Red Hat Single Sign-On for OpenShift
 :openshift_openjdk_link: {project_doc_base_url}/red_hat_single_sign-on_for_openshift/
 :openshift_openjdk_platforms: x86_64
 :openshift_openjdk_image_stream: sso75-openshift-rhel8
@@ -91,9 +91,9 @@
 
 // Aggregate various frequently referred links to the official OCP documentation
 :official_ocp_docs_link: https://docs.openshift.com/container-platform
-:ocpdocs_secrets_link:  {official_ocp_docs_link}/latest/builds/creating-build-inputs.html#builds-secrets-overview_creating-build-inputs
-:ocpdocs_serving_x509_secrets_link: {official_ocp_docs_link}/latest/builds/creating-build-inputs.html#builds-service-serving-certificate-secrets_creating-build-inputs
-:ocpdocs_binary_source_link: {official_ocp_docs_link}/latest/builds/creating-build-inputs.html#builds-binary-source_creating-build-inputs
+:ocpdocs_secrets_link:  {official_ocp_docs_link}/latest/cicd/builds/creating-build-inputs.html#builds-secrets-overview_creating-build-inputs
+:ocpdocs_serving_x509_secrets_link: {official_ocp_docs_link}/latest/cicd/builds/creating-build-inputs.html#builds-service-serving-certificate-secrets_creating-build-inputs
+:ocpdocs_binary_source_link: {official_ocp_docs_link}/latest/builds/cicd/creating-build-inputs.html#builds-binary-source_creating-build-inputs
 :ocpdocs_templates_link: {official_ocp_docs_link}/latest/openshift_images/using-templates.html
 :ocpdocs_idp_config_link: {official_ocp_docs_link}/latest/authentication/understanding-identity-provider.html
 :ocpdocs_htpasswd_idp_link: {official_ocp_docs_link}/latest/authentication/identity_providers/configuring-htpasswd-identity-provider.html

--- a/upgrading/topics/keycloak/changes.adoc
+++ b/upgrading/topics/keycloak/changes.adoc
@@ -430,7 +430,7 @@ for the Google+ API in favor of the new Google Sign-in authentication system. Th
 to use the new endpoints so if this integration is in use make sure you upgrade to {project_name} version 4.8.2 or later.
 
 If you run into an error saying that the application identifier was not found in the directory, you will have to register the client application again in the
-https://console.developers.google.com/apis/credentials[Google API Console] portal to obtain a new application id and secret.
+https://console.cloud.google.com/apis/credentials[Google API Console] portal to obtain a new application id and secret.
 
 It is possible that you will need to adjust custom mappers for non-standard claims that were provided by Google+ user
 information endpoint and are provided under different name by Google Sign-in API. Please consult Google documentation

--- a/upgrading/topics/rhsso/changes-72.adoc
+++ b/upgrading/topics/rhsso/changes-72.adoc
@@ -67,7 +67,7 @@ for the Google+ API in favor of the new Google Sign-in authentication system. Th
 to use the new endpoints so if this integration is in use make sure you upgrade to {project_name} version 7.2.6 or later.
 
 If you run into an error saying that the application identifier was not found in the directory, you will have to register the client application again in the
-https://console.developers.google.com/apis/credentials[Google API Console] portal to obtain a new application id and secret.
+https://console.cloud.google.com/apis/credentials[Google API Console] portal to obtain a new application id and secret.
 
 It is possible that you will need to adjust custom mappers for non-standard claims that were provided by Google+ user
 information endpoint and are provided under different name by Google Sign-in API. Please consult Google documentation
@@ -89,4 +89,3 @@ Due to these privacy restrictions imposed by LinkedIn in regards to access to me
 current member's Profile API, the LinkedIn Social Broker
 is now using the member's email address as the default username. That means that the `r_emailaddress` is always set when
 sending authorization requests during the authentication.
-

--- a/upgrading/topics/rhsso/changes-73.adoc
+++ b/upgrading/topics/rhsso/changes-73.adoc
@@ -145,7 +145,7 @@ for the Google+ API in favor of the new Google Sign-in authentication system. Th
 to use the new endpoints so if this integration is in use make sure you upgrade to the latest {project_name} version.
 
 If you run into an error saying that the application identifier was not found in the directory, you will have to register the client application again in the
-https://console.developers.google.com/apis/credentials[Google API Console] portal to obtain a new application id and secret.
+https://console.cloud.google.com/apis/credentials[Google API Console] portal to obtain a new application id and secret.
 
 It is possible that you will need to adjust custom mappers for non-standard claims that were provided by Google+ user
 information endpoint and are provided under different name by Google Sign-in API. Please consult Google documentation


### PR DESCRIPTION
Also, this includes the OpenShift guide and release note updates to remove OpenJ9 references (see https://issues.redhat.com/browse/CIAM-2258)

Closes #CIAM-2504