### PR TITLE
Reinstate missing step in Server Admin guide

### DIFF
--- a/server_admin/topics/user-federation/sssd.adoc
+++ b/server_admin/topics/user-federation/sssd.adoc
@@ -92,18 +92,14 @@ The federation provider obtains the data from SSSD using D-BUS. It authenticates
 $ sudo yum install sssd-dbus
 ----
 
-ifeval::[{project_community}==true]
-
-. Run the provisioning script available from the Keycloak distribution:
+. Run the following provisioning script:
 +
 [source,bash,subs=+attributes]
 ----
-  $ bin/federation-sssd-setup.sh
+$ bin/federation-sssd-setup.sh
 ----
-
-endif::[]
 +
-This provisioning script makes the following changes to `/etc/sssd/sssd.conf`:
+This script makes the following changes to `/etc/sssd/sssd.conf`:
 +
 [source,bash,subs=+attributes]
 ----


### PR DESCRIPTION
Closes #CIAM-2535

This removes the ifeval to excludes the content from the downstream version.  It does not affect upstream, but upstream must match for future downstream releases.

(cherry picked from commit 9bb0ec4f81ba454c3141800fc5586d34363c9679)