### PR TITLE
Fix typo in bruteforce algo doc

### DIFF
--- a/server_admin/topics/threat/brute-force.adoc
+++ b/server_admin/topics/threat/brute-force.adoc
@@ -89,6 +89,7 @@ When {project_name} disables a user, the user cannot log in until an administrat
 .. Increment `count`
 .. Calculate `wait` using _Wait Increment_ * (`count` / _Max Login Failures_). The division is an integer division rounded down to a whole number
 .. If `wait` equals 0 and the time between this failure and the last failure is less than _Quick Login Check Milliseconds_, set `wait` to _Minimum Quick Login Wait_.
+.. If `wait` > 0
 ... Temporarily disable the user for the smaller of `wait` and _Max Wait_ seconds
 
 'count` does not increment when a temporarily disabled account commits a login failure.


### PR DESCRIPTION
There's a typo in the algo. The disabling is not a chid of "if wait=0...." but at the same level. Moreover, for an easier comprehension  I added the if wait > 0.