### PR TITLE
Deprecation warning for deprecated adapters.

### DIFF
--- a/securing_apps/topics/oidc/java/fuse-adapter.adoc
+++ b/securing_apps/topics/oidc/java/fuse-adapter.adoc
@@ -2,6 +2,8 @@
 [[_fuse_adapter]]
 ==== JBoss Fuse 6 adapter
 
+WARNING: JBoss Fuse 6 adapter has been deprecated and support for it will cease December 2022. Please refer to https://www.keycloak.org/2022/02/adapter-deprecation[Keycloak blog] for more information.
+
 {project_name} supports securing your web applications running inside https://developers.redhat.com/products/fuse/overview[JBoss Fuse 6].
 
 ifeval::[{project_community}==true]

--- a/securing_apps/topics/oidc/java/fuse7-adapter.adoc
+++ b/securing_apps/topics/oidc/java/fuse7-adapter.adoc
@@ -2,6 +2,8 @@
 [[_fuse7_adapter]]
 ==== JBoss Fuse 7 Adapter
 
+WARNING: JBoss Fuse 7 adapter has been deprecated and support for it will cease December 2022. Please refer to https://www.keycloak.org/2022/02/adapter-deprecation[Keycloak blog] for more information.
+
 {project_name} supports securing your web applications running inside https://developers.redhat.com/products/fuse/overview[JBoss Fuse 7].
 
 JBoss Fuse 7 leverages Undertow adapter which is essentially the same as

--- a/securing_apps/topics/oidc/java/java-adapters.adoc
+++ b/securing_apps/topics/oidc/java/java-adapters.adoc
@@ -1,5 +1,7 @@
 === Java adapters
 
+WARNING: Java OIDC adapters have been deprecated and support for them will cease December 2022. Please refer to https://www.keycloak.org/2022/02/adapter-deprecation[Keycloak blog] for more information.
+
 {project_name} comes with a range of different adapters for Java application. Selecting the correct adapter depends on the target platform.
 
 All Java adapters share a set of common configuration options described in the <<_java_adapter_config,Java Adapters Config>> chapter.

--- a/securing_apps/topics/oidc/java/jboss-adapter.adoc
+++ b/securing_apps/topics/oidc/java/jboss-adapter.adoc
@@ -7,6 +7,8 @@ ifeval::[{project_product}==true]
 ==== JBoss EAP adapter
 endif::[]
 
+WARNING: JBoss EAP/Wildfly adapter has been deprecated and support for it will cease December 2022. Please refer to https://www.keycloak.org/2022/02/adapter-deprecation[Keycloak blog] for more information.
+
 You can install this adapter from a ZIP file or from an RPM.
 
 * xref:jboss_adapter_installation[Installing JBOSS EAP adapters from a ZIP file]

--- a/securing_apps/topics/oidc/java/jetty9-adapter.adoc
+++ b/securing_apps/topics/oidc/java/jetty9-adapter.adoc
@@ -2,6 +2,8 @@
 [[_jetty9_adapter]]
 ==== Jetty 9.x adapters
 
+WARNING: Jetty 9.x adapters have been deprecated and support for them will cease December 2022. Please refer to https://www.keycloak.org/2022/02/adapter-deprecation[Keycloak blog] for more information.
+
 Keycloak has a separate adapter for Jetty 9.2.x, Jetty 9.3.x and Jetty 9.4.x that you will have to install into your Jetty installation.
 You then have to provide some extra configuration in each WAR you deploy to Jetty.
 

--- a/securing_apps/topics/oidc/java/servlet-filter-adapter.adoc
+++ b/securing_apps/topics/oidc/java/servlet-filter-adapter.adoc
@@ -1,6 +1,8 @@
 [[_servlet_filter_adapter]]
 ==== Java servlet filter adapter
 
+WARNING: Java servlet filter adapter has been deprecated and support for it will cease December 2022. Please refer to https://www.keycloak.org/2022/02/adapter-deprecation[Keycloak blog] for more information.
+
 If you are deploying your Java Servlet application on a platform where there is no {project_name} adapter you opt to use the servlet filter adapter.
 This adapter works a bit differently than the other adapters. You do not define security constraints in web.xml.
 Instead you define a filter mapping using the {project_name} servlet filter adapter to secure the url patterns you want to secure.

--- a/securing_apps/topics/oidc/java/spring-boot-adapter.adoc
+++ b/securing_apps/topics/oidc/java/spring-boot-adapter.adoc
@@ -1,6 +1,8 @@
 [[_spring_boot_adapter]]
 ==== Spring Boot adapter
 
+WARNING: Spring Boot adapter has been deprecated and support for it will cease December 2022. Please refer to https://www.keycloak.org/2022/02/adapter-deprecation[Keycloak blog] for more information.
+
 ifeval::[{project_product}==true]
 ====
 [NOTE]

--- a/securing_apps/topics/oidc/java/spring-security-adapter.adoc
+++ b/securing_apps/topics/oidc/java/spring-security-adapter.adoc
@@ -2,6 +2,8 @@
 [[_spring_security_adapter]]
 ==== Spring Security adapter
 
+WARNING: Spring Security adapter has been deprecated and support for it will cease December 2022. Please refer to https://www.keycloak.org/2022/02/adapter-deprecation[Keycloak blog] for more information.
+
 To secure an application with Spring Security and Keycloak, add this adapter as a dependency to your project.
 You then have to provide some extra beans in your Spring Security configuration file and add the Keycloak security filter to your pipeline.
 

--- a/securing_apps/topics/oidc/java/tomcat-adapter.adoc
+++ b/securing_apps/topics/oidc/java/tomcat-adapter.adoc
@@ -2,6 +2,8 @@
 [[_tomcat_adapter]]
 ==== Tomcat 7, 8, and 9 adapters
 
+WARNING: Tomcat adapters have been deprecated and support for them will cease December 2022. Please refer to https://www.keycloak.org/2022/02/adapter-deprecation[Keycloak blog] for more information.
+
 To be able to secure WAR apps deployed on Tomcat 7, 8, and 9, you install the Keycloak Tomcat 7 adapter or Keycloak Tomcat adapter into your Tomcat installation. You then perform extra configuration to secure each WAR you deploy to Tomcat.
 
 [[_tomcat_adapter_installation]]

--- a/securing_apps/topics/oidc/nodejs-adapter.adoc
+++ b/securing_apps/topics/oidc/nodejs-adapter.adoc
@@ -1,6 +1,8 @@
 [[_nodejs_adapter]]
 === Node.js adapter
 
+WARNING: Node.js adapter has been deprecated and support for it will cease December 2022. Please refer to https://www.keycloak.org/2022/02/adapter-deprecation[Keycloak blog] for more information.
+
 {project_name} provides a Node.js adapter built on top of https://github.com/senchalabs/connect[Connect] to protect server-side JavaScript apps - the goal was to be flexible enough to integrate with frameworks like https://expressjs.com/[Express.js].
 
 ifeval::[{project_community}==true]

--- a/securing_apps/topics/saml/java/jetty-adapter.adoc
+++ b/securing_apps/topics/saml/java/jetty-adapter.adoc
@@ -2,6 +2,8 @@
 
 ==== Jetty SAML adapters
 
+WARNING: Jetty SAML adapter has been deprecated and support for it will cease December 2022. Please refer to https://www.keycloak.org/2022/02/adapter-deprecation[Keycloak blog] for more information.
+
 To be able to secure WAR apps deployed on Jetty you must install the {project_name} Jetty 9.x SAML adapter into your Jetty installation. You then provide some extra configuration in each WAR you deploy to Jetty.
 
 Use the following installation and configuration procedures.

--- a/securing_apps/topics/saml/java/tomcat-adapter.adoc
+++ b/securing_apps/topics/saml/java/tomcat-adapter.adoc
@@ -2,6 +2,8 @@
 
 ==== Tomcat SAML adapters
 
+WARNING: Tomcat SAML adapter has been deprecated and support for it will cease December 2022. Please refer to https://www.keycloak.org/2022/02/adapter-deprecation[Keycloak blog] for more information.
+
 To be able to secure WAR apps deployed on Tomcat 7, 8 and 9 you must install the Keycloak Tomcat 7 SAML adapter or Keycloak Tomcat SAML adapter into your Tomcat installation.
 You then have to provide some extra configuration in each WAR you deploy to Tomcat.
 


### PR DESCRIPTION
Added warning to deprecated adapters, based on this keycloak blog post [https://www.keycloak.org/2022/02/adapter-deprecation](url)

Should same warning be added to OIDC Client authentication and OIDC JAAS plugin?