### PR TITLE
It took me a while to notice this myself

### DIFF
--- a/securing_apps/topics/oidc/javascript-adapter.adoc
+++ b/securing_apps/topics/oidc/javascript-adapter.adoc
@@ -580,7 +580,7 @@ Invoking this results in onAuthLogout callback listener being invoked.
 
 ===== Callback Events
 
-The adapter supports setting callback listeners for certain events.
+The adapter supports setting callback listeners for certain events. Keep in mind that these have to be set before the call to the `init` function.
 
 For example:
 [source,javascript]


### PR DESCRIPTION
I did change the `onTokenExpired` after the init function, not knowing that this would cause nothing to happen. Hence, I think the extra hint here is helpful.

Ideally, we would have an "updateEvent" function in the keycloak provider.