### PR TITLE
Correcting wrong cross-reference

### DIFF
--- a/server_admin/topics/identity-broker/oidc.adoc
+++ b/server_admin/topics/identity-broker/oidc.adoc
@@ -2,7 +2,7 @@
 [[_identity_broker_oidc]]
 === OpenID Connect v1.0 identity providers
 
-{project_name} brokers identity providers based on the OpenID Connect protocol. These identity providers (IDPs) must support the xref:proc-creating-oidc-client_{context}[Authorization Code Flow] defined in the specification to authenticate users and authorize access.
+{project_name} brokers identity providers based on the OpenID Connect protocol. These identity providers (IDPs) must support the xref:con-oidc-auth-flows_{context}[Authorization Code Flow] defined in the specification to authenticate users and authorize access.
 
 
 .Procedure


### PR DESCRIPTION
New link goes to OIDC Auth Flows section

Closes #1504 

@pskopek, @pdrozd Can you approve this minor correction to a cross-reference?