### PR TITLE
Issue #9194: Client authentication fails when using signed JWT, if the JWA signing algorithm is not RS256

### DIFF
--- a/securing_apps/topics/oidc/java/client-authentication.adoc
+++ b/securing_apps/topics/oidc/java/client-authentication.adoc
@@ -45,6 +45,7 @@ For set up on the adapter side you need to have something like this in your `key
     "client-keystore-password": "storepass",
     "client-key-password": "keypass",
     "client-key-alias": "clientkey",
+    "algorithm": "RS256",
     "token-expiration": 10
   }
 }
@@ -52,6 +53,10 @@ For set up on the adapter side you need to have something like this in your `key
 
 With this configuration, the keystore file `keystore-client.jks` must be available on classpath in your WAR. If you do not use the prefix `classpath:`
 you can point to any file on the file system where the client application is running.
+
+The `algorithm` field specifies the algorithm used for the Signed JWT and it defaults to `RS256`. This field should be in sync with the key pair.
+For example, the `RS256` algorithm needs a RSA key pair while the `ES256` algorithm requires an EC key pair. Please refer to
+https://datatracker.ietf.org/doc/html/rfc7518#section-3[Cryptographic Algorithms for Digital Signatures and MACs] for more information.
 
 ifeval::[{project_community}==true]
 For inspiration, you can take a look at the examples distribution into the main demo example into the `product-portal` application.


### PR DESCRIPTION
Issue: https://github.com/keycloak/keycloak/issues/9194

Just a little modification to add the `algorithm` field for the `jwt` credentials configuration for java clients. You can change any word you like or ask me to do it.

Thanks!