### PR TITLE
For the product documentation, replace the section identifier as well to retrieve the local filename.

### DIFF
--- a/tests/src/test/java/org/keycloak/documentation/test/Guide.java
+++ b/tests/src/test/java/org/keycloak/documentation/test/Guide.java
@@ -59,7 +59,7 @@ public class Guide {
     private String rewriteLinksToGuides(Config config, String body) throws MalformedURLException {
         if (config.isLoadFromFiles()) {
             for (Map.Entry<String, String> e : config.getGuideFragmentToDir().entrySet()) {
-                String originalUrl = config.getDocBaseUrl() + "/" + e.getKey() + "/";
+                String originalUrl = config.getDocBaseUrl() + "/" + e.getKey() + "/" + (config.isCommunity() ? "" : "(\\w*)?");
                 String replacementUrl = config.getGuideHtmlFile(e.getValue()).toURI().toURL().toString();
 
                 body = body.replace("href=\"" + originalUrl, "href=\"" + replacementUrl);


### PR DESCRIPTION
Closes #1589