### PR TITLE
Adding rules to check documentation in an IntelliJ's editor

### DIFF
--- a/.grazie.en.yaml
+++ b/.grazie.en.yaml
@@ -1,0 +1,27 @@
+# The "en" in the file name specifies the natural language to be checked, so users can use other ISO codes, for example, "ru" or "de"
+
+# A subset of "vale" linter syntax is supported, see https://plugins.jetbrains.com/plugin/16136-grazie-professional/docs/project-style-guides.html.
+#
+# See https://docs.errata.ai/vale/styles#extension-points for more details on each rule.
+
+extends: existence                # check for unwanted words or phrases
+message: Do not use '%s'           # a message to display in the inspection tooltip when a matching fragment is found
+ignorecase: true
+tokens:
+  - just
+
+---
+extends: substitution             # check for unwanted fragments and suggest replacements
+message: Use '%s'
+ignorecase: true
+swap:
+  via: using|through
+  e.g.: for example|such as
+  i.e.: that is
+  don't: do not
+  doesn't: does not
+  won't: will not
+  you'll: you will
+  vs.: versus
+  like: such as
+

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="com.intellij.grazie.pro" />
+    <plugin id="org.asciidoctor.intellij.asciidoc" />
+    <plugin id="tanvd.grazi" />
+  </component>
+</project>

--- a/internal_resources/styleguide.adoc
+++ b/internal_resources/styleguide.adoc
@@ -6,6 +6,7 @@
 . This document
 
 Writers will also refer to these:
+
 . link:https://www.ibm.com/developerworks/library/styleguidelines/[IBM DeveloperWorks Editorial Style Guide]
 . link:http://brand.redhat.com/elements/[RH Corporate]
 


### PR DESCRIPTION
Hi @andymunro - here is a PR to add project-styles to IntelliJ's proofreading. 

I also considered adding the IBM style guide (see parent issue). While they look valid, all highlighting now links to a now invalid website of the style guide. Do you happen to know a new URL?

The is the (broken) URL: https://www.ibm.com/developerworks/library/styleguidelines/

Closes #1604