### PR TITLE
Fixing formatting in Server Administration guide

### DIFF
--- a/server_admin/topics/sessions/timeouts.adoc
+++ b/server_admin/topics/sessions/timeouts.adoc
@@ -134,6 +134,7 @@ image:{project_images}/sessions-tab.png[Sessions Tab]
 
 |Login action timeout
 |The Maximum time users can spend on any one page during the authentication process.
+|===
 
 .Tokens tab
 image:{project_images}/tokens-tab.png[Tokens Tab]
@@ -174,6 +175,7 @@ image:{project_images}/tokens-tab.png[Tokens Tab]
 
 |Execute actions
 | Specifies independent timeout for execute actions.
+|===
 endif::[]
 
 [[_idle_timeouts_note]]


### PR DESCRIPTION
Closes #1650
@ssilvert This fixes a problem with two tables overlapping in the Managing Sessions chapter.  Can you merge this?