### PR TITLE
Synching from downstream:  Operator upgrade fails for RH SSO 7.6

### DIFF
--- a/release_notes/topics/product/7_6.adoc
+++ b/release_notes/topics/product/7_6.adoc
@@ -88,13 +88,14 @@ For more details on this change, see link:https://access.redhat.com/articles/674
 
 For details on the issues fixed between RH-SSO 7.5 and 7.6.0, see link:https://issues.redhat.com/browse/KEYCLOAK-14085?filter=12396918[RHSSO 7.6.0 Fixed Issues].
 
+After 7.6.0 release we also introduced a patch release for the {project_operator} to fix a
+https://issues.redhat.com/browse/RHSSO-2091[critical issue] that prevented the upgrade from 7.5.2 to 7.6.0 using the Operator.
+See the link:{upgradingguide_link}#rh_sso_7_6[{upgradingguide_name}] for more details and caveats.
+
 = Known issues
 
 This release includes the following known issues:
 
-* link:https://issues.redhat.com/browse/RHSSO-2091[RHSSO-2091] - Operator fails to upgrade to 7.6.0 GA with the error "FAILED Update RHSSO Deployment (StatefulSet)"
-+
-See this link:https://access.redhat.com/solutions/6966958[KCS solution].
 * link:https://issues.redhat.com/browse/KEYCLOAK-18115[KEYCLOAK-18115] - Attempt to edit attribute denied in RHSSO 7.4.6
 
 = Supported configurations

--- a/server_installation/topics/operator/upgrading.adoc
+++ b/server_installation/topics/operator/upgrading.adoc
@@ -36,6 +36,17 @@ spec:
     enabled: True
 ```
 
+[NOTE]
+====
+Due to a https://github.com/keycloak/keycloak-operator/issues/566[bug] introduced in a previous version of the Operator, `Selector` field on the {project_name} StatefulSet might
+be misconfigured depending on your configuration. If such state is detected by the Operator and you are using the `recreate`
+strategy, it will **delete and recreate the StatefulSet** with the correct `Selector` field. This is required as the
+`Selector` field is immutable.
+
+As a "delete" operation can have potentially dangerous side effects in very rare cases, for example when you have added custom
+functionality unknown to the Operator to the StatefulSet definition, you can instead delete the StatefulSet manually.
+====
+
 ifeval::[{project_community}==true]
 .Additional Resources
 

--- a/upgrading/topics/rhsso/changes-76.adoc
+++ b/upgrading/topics/rhsso/changes-76.adoc
@@ -169,3 +169,11 @@ spec:
 ```
 See also the https://kubernetes.io/docs/tasks/run-application/configure-pdb/[Kubernetes Documentation].
 
+=== Critical bug fix in the {project_operator}
+
+Due to a https://issues.redhat.com/browse/RHSSO-2091[critical bug] introduced in the previous versions of the Operator, `Selector` field on the RH-SSO StatefulSet
+was misconfigured. The misconfiguration may break the upgrade process from 7.5 to 7.6, preventing a successful RH-SSO deployment.
+
+With an Operator patch release we introduced a fix. Please note that as part of the fix the Operator may **delete and recreate the
+RH-SSO StatefulSet** during the upgrade from 7.5 to 7.6. For the fix to work properly, make sure you use the `recreate`
+upgrade strategy. Refer to the related chapter of link:{installguide_link}#_operator-upgrade-strategy[{installguide_name}].


### PR DESCRIPTION
Closes #1655 

(cherry picked from commit 9fcb4e0c74308c26eb5c008a033b5a5327526bd2)