### PR TITLE
Fix formatting of ${vault.key} variables

### DIFF
--- a/server_admin/topics/vault.adoc
+++ b/server_admin/topics/vault.adoc
@@ -7,7 +7,7 @@ To obtain a secret from a vault rather than entering it directly, enter the foll
 
 [source]
 ----
-**${vault.**_key_**}**
+${vault.key}
 ----
 where the `_key_` is the name of the secret recognized by the vault.
 


### PR DESCRIPTION
Since the `${vault.key}` is part of a `source` block, it is currently rendered confusingly in the documentation. See: https://www.keycloak.org/docs/latest/server_admin/#_vault-administration

I think removing all markup from it is the correct way to display it there.