### PR TITLE
Document how to force refresh access token in JS adapter

### DIFF
--- a/securing_apps/topics/oidc/javascript-adapter.adoc
+++ b/securing_apps/topics/oidc/javascript-adapter.adoc
@@ -556,7 +556,8 @@ Returns true if the token has less than minValidity seconds left before it expir
 *updateToken(minValidity)*
 
 If the token expires within minValidity seconds (minValidity is optional, if not specified 5 is used) the token is refreshed.
-If the session status iframe is enabled, the session status is also checked.
+If -1 is passed as the minValidity, the token will be forcibly refreshed. 
+If the session status iframe is enabled, the session status is also checked. 
 
 Returns a promise that resolves with a boolean indicating whether or not the token has been refreshed.
 


### PR DESCRIPTION
I was reading the documentation of the Javascript adapter to try and work out how to forcibly refresh an access token. There was no mention in the documentation on how to do this but I noticed in the actual code that this can be achieved by passing -1 to the updateToken function (https://github.com/keycloak/keycloak-ui/blob/main/libs/keycloak-js/src/keycloak.js#L615).

This PR updates the documentation to make it clearer how an access token can be forcibly refreshed.