### PR TITLE
remove formatting characters from vault key literal code

### DIFF
--- a/server_admin/topics/vault.adoc
+++ b/server_admin/topics/vault.adoc
@@ -7,11 +7,11 @@ To obtain a secret from a vault rather than entering it directly, enter the foll
 
 [source]
 ----
-**${vault.**_key_**}**
+${vault.key}
 ----
-where the `_key_` is the name of the secret recognized by the vault.
+where the `key` is the name of the secret recognized by the vault.
 
-To prevent secrets from leaking across realms, {project_name} combines the realm name with the `_key_` obtained from the vault expression. This method means that the `_key_` does not directly map to an entry in the vault but creates the final entry name according to the algorithm used to combine the `_key_` with the realm name.
+To prevent secrets from leaking across realms, {project_name} combines the realm name with the `key` obtained from the vault expression. This method means that the `key` does not directly map to an entry in the vault but creates the final entry name according to the algorithm used to combine the `key` with the realm name.
 
 You can obtain the secret from the vault in the following fields:
 


### PR DESCRIPTION
The renderer for the hosted documentation was not handling the markdown formatting characters as expected, resulting in an incorrect example for the key reference.

The asterisks and underscores should not have been shown in the key reference example. I removed the underscores from the other key references because I think they were confusing when reading the markdown and I thought it was unnecessary to italicize them.

![image](https://user-images.githubusercontent.com/2521644/209222836-25a1b5b5-9611-40e1-90f3-22fe15c60552.png)
