### PR TITLE
Metrics enabled for Infinispan

### DIFF
--- a/release_notes/topics/21_0_0.adoc
+++ b/release_notes/topics/21_0_0.adoc
@@ -11,3 +11,8 @@ See the migration guide for details.
 We removed the out-of-box support for Hashicorp vault in this release.
 
 See this https://github.com/keycloak/keycloak/discussions/16446[discussion] for more details.
+
+= Metrics for embedded Infinispan as preview
+
+When metrics are enabled and {project_name} uses the embedded {jdgserver_name}, the metrics endpoint exposes information about caches using the `/metrics` endpoint in the metrics with names starting with `vendor_cache_*`.
+Those metrics are currently a preview feature and might change in upcoming releases.

--- a/release_notes/topics/21_0_0.adoc
+++ b/release_notes/topics/21_0_0.adoc
@@ -15,4 +15,5 @@ See this https://github.com/keycloak/keycloak/discussions/16446[discussion] for 
 = Metrics for embedded Infinispan as preview
 
 When metrics are enabled and {project_name} uses the embedded {jdgserver_name}, the metrics endpoint exposes information about caches using the `/metrics` endpoint in the metrics with names starting with `vendor_cache_*`.
-Those metrics are currently a preview feature and might change in upcoming releases.
+Those metrics use the original pattern as provided by {jdgserver_name}.
+They are currently a preview feature and might change in upcoming releases, especially when the {jdgserver_name} is updated in such a release.


### PR DESCRIPTION
keycloak/keycloak#15901

@sschu - this adds a release notes entry for KC21 that metrics for Infinispan are now available via the metrics endpoint. 

I also want to declare them as a preview feature, as those metrics names can change (and probably will change looking at their names). At the same time, those changes are probably due in the upstream project, like hiding the node name as a dimension and removing the duplicated cache name from the metric. 

