### PR TITLE
Link now available via https redirect, fixing the external link check

### DIFF
--- a/server_admin/topics/threat/clickjacking.adoc
+++ b/server_admin/topics/threat/clickjacking.adoc
@@ -4,7 +4,7 @@
 Clickjacking is a technique of tricking users into clicking on a user interface element different from what users perceive. A malicious site loads the target site in a transparent iFrame, overlaid on top of a set of dummy buttons placed directly under important buttons on the target site. When a user clicks a visible button, they are clicking a button on the hidden page. An attacker can steal a user's authentication credentials and access their resources by using this method.
 
 By default, every response by {project_name} sets some specific HTTP headers that can prevent this from happening.
-Specifically, it sets https://datatracker.ietf.org/doc/html/rfc7034[X-Frame-Options] and http://www.w3.org/TR/CSP/[Content-Security-Policy].
+Specifically, it sets https://datatracker.ietf.org/doc/html/rfc7034[X-Frame-Options] and https://www.w3.org/TR/CSP/[Content-Security-Policy].
 You should take a look at the definition of both of these headers as there is a lot of fine-grain browser access you can control.
 
 .Procedure


### PR DESCRIPTION
This fixes the build problem: 

> Broken links (1):
		- http://www.w3.org/TR/CSP/ (invalid redirect to https://www.w3.org/TR/CSP/)
	at org.keycloak.documentation.test.ExternalLinksTest.checkExternalLinks(ExternalLinksTest.java:26)