### PR TITLE
fix read-only user attributes configuration options

### DIFF
--- a/server_admin/topics/threat/read-only-attributes.adoc
+++ b/server_admin/topics/threat/read-only-attributes.adoc
@@ -29,11 +29,16 @@ This is the list of the read-only attributes, which are used internally by the {
 
 System administrators have a way to add additional attributes to this list. The configuration is currently available at the server level.
 
-You can add this configuration by using the `spi-user-profile-legacy-user-profile-read-only-attributes` and ``spi-user-profile-legacy-user-profile-admin-read-only-attributes` options. For example:
+You can add this configuration by using the `spi-user-profile-declarative-user-profile-read-only-attributes` and `spi-user-profile-declarative-user-profile-admin-read-only-attributes` options. For example:
 
 [source,bash,options="nowrap"]
 ----
-kc.[sh|bat] start --spi-user-profile-legacy-user-profile-read-only-attributes=foo,bar*
+kc.[sh|bat] start --spi-user-profile-declarative-user-profile-read-only-attributes=foo,bar*
+----
+or leveraging environment variables
+[source,bash,options="nowrap"]
+----
+KC_SPI_USER_PROFILE_DECLARATIVE_USER_PROFILE_READ_ONLY_ATTRIBUTES=foo,bar kc.[sh|bat] start
 ----
 
 For this example, users and administrators would not be able to update attribute `foo`. Users would not be able to edit any attributes starting with the `bar`.


### PR DESCRIPTION
This cost me several hours of debugging and frustration. :-) I'm surprise that the setting already follows the upcoming declarative-user-profile even though this feature is still in preview?
Anyways, I managed to verify that the config is loaded with this updated settings with Keycloak 20.0.3.

`AbstractUserProfileProvider#init`

<img width="1072" alt="Screenshot 2023-02-24 at 14 49 08" src="https://user-images.githubusercontent.com/1713109/221224061-75b8ffc6-d730-4ade-980b-038935ab01d2.png">

