### PR TITLE
Use a valid SemVer format for the SNAPSHOT version

### DIFF
--- a/aggregation/pom.xml
+++ b/aggregation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/api_documentation/pom.xml
+++ b/api_documentation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/authorization_services/pom.xml
+++ b/authorization_services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/header-maven-plugin/pom.xml
+++ b/header-maven-plugin/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>documentation-parent</artifactId>
         <groupId>org.keycloak.documentation</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.keycloak.documentation</groupId>
     <artifactId>header-maven-plugin</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>999.0.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>github-maven-plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Keycloak Documentation Parent</name>
     <groupId>org.keycloak.documentation</groupId>
     <artifactId>documentation-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>999.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -121,7 +121,7 @@
                 <plugin>
                     <groupId>org.keycloak.documentation</groupId>
                     <artifactId>header-maven-plugin</artifactId>
-                    <version>999-SNAPSHOT</version>
+                    <version>999.0.0-SNAPSHOT</version>
                     <executions>
                         <execution>
                             <id>add-file-headers</id>

--- a/release_notes/pom.xml
+++ b/release_notes/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/securing_apps/pom.xml
+++ b/securing_apps/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/server_admin/pom.xml
+++ b/server_admin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/server_development/pom.xml
+++ b/server_development/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/topics/templates/document-attributes.adoc
+++ b/topics/templates/document-attributes.adoc
@@ -3,8 +3,8 @@
 :project_community: true
 :project_product: false
 :project_version: DEV
-:project_versionMvn: 999-SNAPSHOT
-:project_versionNpm: 999
+:project_versionMvn: 999.0.0-SNAPSHOT
+:project_versionNpm: 999.0.0-SNAPSHOT
 :project_versionDoc: DEV
 
 :standalone:

--- a/upgrading/pom.xml
+++ b/upgrading/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
Changes the default version string from `999-SNAPSHOT` to `999.0.0-SNAPSHOT`. This makes it a valid version under the [Semantic Versioning](https://semver.org/) standard.

The motivation for this change is to make versioning interoperable between Maven and NPM, as the latter only allows for Semantic Versioning. This allows for simplification in the release process, as we no longer need to convert version numbers from one to the other.

For more information see https://github.com/keycloak/keycloak/issues/17335.