### PR TITLE
[Documentation] Changed Jboss datadir to kc.home.dir

### DIFF
--- a/server_admin/topics/authentication/password-policies.adoc
+++ b/server_admin/topics/authentication/password-policies.adoc
@@ -83,6 +83,6 @@ Password must not be in a blacklist file.
 * Blacklist files are UTF-8 plain-text files with Unix line endings. Every line represents a blacklisted password.
 * {project_name} compares passwords in a case-insensitive manner. All passwords in the blacklist must be lowercase.
 * The value of the blacklist file must be the name of the blacklist file.
-* Blacklist files resolve against `${jboss.server.data.dir}/password-blacklists/` by default. Customize this path using:
+* Blacklist files resolve against `${kc.home.dir}/data/password-blacklists/` by default. Customize this path using:
 ** The `keycloak.password.blacklists.path` property.
 ** The `blacklistsPath` property of the `passwordBlacklist` policy SPI configuration.


### PR DESCRIPTION
Password-blacklist directory is stored at `{kc_home_dir}/data. See https://github.com/keycloak/keycloak/issues/10608