### PR TITLE
Document T&C user attribute migration needed in 21.0.2

### DIFF
--- a/upgrading/topics/keycloak/changes-21_0_2.adoc
+++ b/upgrading/topics/keycloak/changes-21_0_2.adoc
@@ -1,0 +1,9 @@
+= Terms and Conditions user attribute migration
+
+The `terms_and_conditions` user attribute was accidentally changed in 21.0.0
+to uppercase. This version reverts the user attribute back to lowercase.
+The value of the attribute is set when accepting Terms and Conditions page.
+
+If any of your custom extensions relies on this attribute, you may need to
+adjust your code to check both attributes `terms_and_conditions` and
+`TERMS_AND_CONDITIONS`.

--- a/upgrading/topics/keycloak/changes.adoc
+++ b/upgrading/topics/keycloak/changes.adoc
@@ -1,5 +1,9 @@
 == Migration Changes
 
+=== Migrating to 21.0.2
+
+include::changes-21_0_2.adoc[leveloffset=3]
+
 === Migrating to 21.0.0
 
 include::changes-21_0_0.adoc[leveloffset=3]


### PR DESCRIPTION
This is documentation backport for https://github.com/keycloak/keycloak/issues/17277